### PR TITLE
go: small refactor of http code, build pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,32 @@
-FROM ghcr.io/grafana/quickpizza-base:latest as build
+FROM node:16.19.1-bullseye as fe-builder
 
-WORKDIR /app
+WORKDIR /app/pkg/web
+COPY pkg/web ./
 
+# TODO: Allow reading these vars in runtime.
 ARG PUBLIC_BACKEND_ENDPOINT=http://localhost:3333/
 ENV PUBLIC_BACKEND_ENDPOINT=${PUBLIC_BACKEND_ENDPOINT}
 ARG PUBLIC_BACKEND_WS_ENDPOINT=ws://localhost:3333/
 ENV PUBLIC_BACKEND_WS_ENDPOINT=${PUBLIC_BACKEND_WS_ENDPOINT}
 
-RUN go generate pkg/web/web.go 
+RUN npm install && \
+    npm run build
 
-RUN GO111MODULE=on CGO_ENABLED=0 go build -o bin/quickpizza
+FROM golang:1.20-bullseye as builder
+
+WORKDIR /app
+COPY . ./
+COPY --from=fe-builder /app/pkg/web/build /app/pkg/web/build
+RUN go generate pkg/web/web.go && \
+    GO111MODULE=on CGO_ENABLED=0 go build -o /bin/quickpizza ./cmd
 
 FROM gcr.io/distroless/static-debian11
 
-COPY --from=build /app/bin/quickpizza /
-COPY --from=build /app/data.json /data.json
+COPY --from=builder /bin/quickpizza /bin
+COPY data.json /
 
-ENTRYPOINT [ "./quickpizza" ]
+# Serve all microservices by default
+ENV QP_ALL_SERVICES=1
+
+EXPOSE 3333
+ENTRYPOINT [ "/bin/quickpizza" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=builder /bin/quickpizza /bin
 COPY data.json /
 
 # Serve all microservices by default
-ENV QP_ALL_SERVICES=1
+ENV QUICKPIZZA_ALL_SERVICES=1
 
 EXPOSE 3333
 ENTRYPOINT [ "/bin/quickpizza" ]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,16 +20,16 @@ func main() {
 		globalLogger.Fatal("Cannot create server", zap.Error(err))
 	}
 
-	if envServe("QP_FRONTEND") {
+	if envServe("QUICKPIZZA_FRONTEND") {
 		server = server.WithFrontend()
 	}
 
-	if envServe("QP_WS") {
+	if envServe("QUICKPIZZA_WS") {
 		server = server.WithWS()
 	}
 
 	// TODO: Split this further in subsequent PRs.
-	if envServe("QP_API") {
+	if envServe("QUICKPIZZA_API") {
 		server = server.WithAPI()
 	}
 
@@ -41,7 +41,7 @@ func main() {
 }
 
 func envServe(name string) bool {
-	return envBool("QP_ALL_SERVICES") || envBool(name)
+	return envBool("QUICKPIZZA_ALL_SERVICES") || envBool(name)
 }
 
 func envBool(name string) bool {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	http "net/http"
+	"os"
+	"strconv"
+
+	qphttp "github.com/grafana/quickpizza/pkg/http"
+	"go.uber.org/zap"
+)
+
+func main() {
+	globalLogger, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+
+	server, err := qphttp.NewServer(globalLogger)
+	if err != nil {
+		globalLogger.Fatal("Cannot create server", zap.Error(err))
+	}
+
+	if envServe("QP_FRONTEND") {
+		server = server.WithFrontend()
+	}
+
+	if envServe("QP_WS") {
+		server = server.WithWS()
+	}
+
+	// TODO: Split this further in subsequent PRs.
+	if envServe("QP_API") {
+		server = server.WithAPI()
+	}
+
+	globalLogger.Info("Starting QuickPizza. Listening on :3333")
+	err = http.ListenAndServe(":3333", server)
+	if err != nil {
+		globalLogger.Error("Running HTTP server", zap.Error(err))
+	}
+}
+
+func envServe(name string) bool {
+	return envBool("QP_ALL_SERVICES") || envBool(name)
+}
+
+func envBool(name string) bool {
+	v, found := os.LookupEnv(name)
+	if !found {
+		return false
+	}
+
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+
+	return b
+}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -2,7 +2,5 @@ package web
 
 import "embed"
 
-//go:generate npm i
-//go:generate npm run build
 //go:embed all:build
 var EmbeddedFiles embed.FS


### PR DESCRIPTION
This will be the first PR in a series that aim to give the Quickpizza application two deployment modes:

1. A single service handling all endpoints, exactly as it is now. This will be the default mode.
2. A new mode splitting the API into several deployments, i.e. in a microservice architecture.

The goals for 2 are:
- There will be one single build pipeline for the application, which will produce a binary/image capable of deploying in both modes.
- Microservices-style deployment will be achieved by running different deployments of the same image, each with certain endpoints enabled/disabled in runtime.

Towards this goal, this PR adds runtime, env-var based switches to control whether certain endpoints are enabled, and tweaks the build pipeline a bit.

Subsequent PRs will further split the service and add env-var based config options so multiple services can find each other.