### PR TITLE
Split backend into several microservices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,7 @@ RUN go generate pkg/web/web.go && \
 FROM gcr.io/distroless/static-debian11
 
 COPY --from=builder /bin/quickpizza /bin
-COPY data.json /
-
-# Serve all microservices by default
-ENV QUICKPIZZA_ALL_SERVICES=1
+COPY data.json .
 
 EXPOSE 3333
 ENTRYPOINT [ "/bin/quickpizza" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM node:16.19.1-bullseye as fe-builder
 WORKDIR /app/pkg/web
 COPY pkg/web ./
 
-# TODO: Allow reading these vars in runtime.
-ARG PUBLIC_BACKEND_ENDPOINT=http://localhost:3333/
+# Define public endpoints. If empty (default), the frontend will use the hostname used to load the page.
+ARG PUBLIC_BACKEND_ENDPOINT=""
 ENV PUBLIC_BACKEND_ENDPOINT=${PUBLIC_BACKEND_ENDPOINT}
-ARG PUBLIC_BACKEND_WS_ENDPOINT=ws://localhost:3333/
+ARG PUBLIC_BACKEND_WS_ENDPOINT=""
 ENV PUBLIC_BACKEND_WS_ENDPOINT=${PUBLIC_BACKEND_WS_ENDPOINT}
 
 RUN npm install && \

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,10 +33,15 @@ func main() {
 	// If QUICKPIZZA_OTLP_ENDPOINT is set, set up tracing outputting to it.
 	// If it is not set, no tracing will be performed.
 	if otlpEndpoint, _ := os.LookupEnv("QUICKPIZZA_OTLP_ENDPOINT"); otlpEndpoint != "" {
+		serviceName, _ := os.LookupEnv("QUICKPIZZA_OTLP_SERVICE_NAME")
+		if serviceName == "" {
+			serviceName = "QuickPizza"
+		}
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		tp, err := tracing.OTLPProvider(ctx, otlpEndpoint)
+		tp, err := tracing.OTLPProvider(ctx, otlpEndpoint, serviceName)
 		if err != nil {
 			globalLogger.Fatal("Cannot create OTLP tracer", zap.Error(err))
 		}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.16.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.16.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.16.0
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
@@ -32,11 +33,9 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.8.0 // indirect
-	go.uber.org/goleak v1.2.1 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -273,9 +273,7 @@ go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.8.0 h1:CUhrE4N1rqSE6FM9ecihEjRkLQu8cDfgDyoOs83mEY4=
 go.uber.org/atomic v1.8.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
-go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
-go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -35,11 +35,21 @@ type InMemoryDatabase struct {
 }
 
 // Transaction provides a thread-safe, read-only view of the data in the database.
-func (db *InMemoryDatabase) Transaction(readF func(data *Data)) {
+func (db *InMemoryDatabase) Transaction(readF func(data Data)) {
 	db.mx.Lock()
-	defer db.mx.Unlock()
+	dataCopy := Data{}
+	dataCopy.Doughs = append(dataCopy.Doughs, db.data.Doughs...)
+	dataCopy.OliveOils = append(dataCopy.OliveOils, db.data.OliveOils...)
+	dataCopy.Tomatoes = append(dataCopy.Tomatoes, db.data.Tomatoes...)
+	dataCopy.Mozzarellas = append(dataCopy.Mozzarellas, db.data.Mozzarellas...)
+	dataCopy.Toppings = append(dataCopy.Toppings, db.data.Toppings...)
+	dataCopy.Tools = append(dataCopy.Tools, db.data.Tools...)
+	dataCopy.Adjectives = append(dataCopy.Adjectives, db.data.Adjectives...)
+	dataCopy.ClassicNames = append(dataCopy.ClassicNames, db.data.ClassicNames...)
+	dataCopy.Quotes = append(dataCopy.Quotes, db.data.Quotes...)
+	db.mx.Unlock()
 
-	readF(&db.data)
+	readF(dataCopy)
 }
 
 func (db *InMemoryDatabase) PopulateFromFile(path string) error {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,0 +1,98 @@
+package database
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+
+	"github.com/grafana/quickpizza/pkg/pizza"
+)
+
+type Data struct {
+	Doughs []pizza.Dough `json:"doughs"`
+
+	// Ingredients
+	OliveOils   []pizza.Ingredient `json:"olive_oils"`
+	Tomatoes    []pizza.Ingredient `json:"tomatoes"`
+	Mozzarellas []pizza.Ingredient `json:"mozzarellas"`
+	Toppings    []pizza.Ingredient `json:"toppings"`
+
+	// Important stuff
+	Tools []string `json:"tools"`
+
+	// Naming
+	Adjectives   []string `json:"adjectives"`
+	ClassicNames []string `json:"classic_names"`
+
+	// Quotes
+	Quotes []string `json:"quotes"`
+}
+
+type InMemoryDatabase struct {
+	mx                  sync.Mutex
+	data                Data
+	lastRecommendations []pizza.Pizza
+}
+
+// Transaction provides a thread-safe, read-only view of the data in the database.
+func (db *InMemoryDatabase) Transaction(readF func(data *Data)) {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	readF(&db.data)
+}
+
+func (db *InMemoryDatabase) PopulateFromFile(path string) error {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	err = decoder.Decode(&db.data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *InMemoryDatabase) PersistToFile(path string) error {
+	d.mx.Lock()
+	defer d.mx.Unlock()
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	err = encoder.Encode(&d.data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (db *InMemoryDatabase) SetLatestPizza(pizza pizza.Pizza) {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	// TODO: Store only the last 10 pizzas
+	db.lastRecommendations = append(db.lastRecommendations, pizza)
+}
+
+func (db *InMemoryDatabase) History() []pizza.Pizza {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	var history []pizza.Pizza
+	copy(history, db.lastRecommendations)
+	return history
+}

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -1,0 +1,203 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/grafana/quickpizza/pkg/pizza"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// CatalogClient is a client that queries the Catalog service.
+type CatalogClient struct {
+	CatalogUrl     string
+	TracerProvider trace.TracerProvider
+	Ctx            context.Context
+}
+
+// WithRequestContext returns a copy of the CatalogClient that will use the supplied context.
+// This context should come from a http.Request, and if provided, CatalogClient will:
+// - Extract parent tracer and trace IDs from it and propagate it to the requests it makes.
+// - Extract the QuickPizza user ID from it and propagate it as well.
+func (c CatalogClient) WithRequestContext(ctx context.Context) CatalogClient {
+	c.Ctx = ctx
+	return c
+}
+
+func (c CatalogClient) Ingredients(ingredientType string) ([]pizza.Ingredient, error) {
+	var ingredients struct {
+		Ingredients []pizza.Ingredient
+	}
+
+	url := c.CatalogUrl + "/api/ingredients/" + ingredientType
+	err := getJSON(c.Ctx, url, &ingredients)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return ingredients.Ingredients, nil
+}
+
+func (c CatalogClient) Tools() ([]string, error) {
+	var tools struct {
+		Tools []string
+	}
+	url := c.CatalogUrl + "/api/tools"
+	err := getJSON(c.Ctx, url, &tools)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return tools.Tools, nil
+}
+
+func (c CatalogClient) Doughs() ([]pizza.Dough, error) {
+	var doughs struct {
+		Doughs []pizza.Dough
+	}
+	url := c.CatalogUrl + "/api/doughs"
+	err := getJSON(c.Ctx, url, &doughs)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return doughs.Doughs, nil
+}
+
+func (c CatalogClient) RecordRecommendation(p pizza.Pizza) error {
+	return postJSON(c.Ctx, c.CatalogUrl+"/api/internal/recommendations", p)
+}
+
+// CopyClient is a client that queries the Copy service.
+type CopyClient struct {
+	CopyURL string
+	Ctx     context.Context
+}
+
+func (c CopyClient) WithRequestContext(ctx context.Context) CopyClient {
+	c.Ctx = ctx
+	return c
+}
+
+func (c CopyClient) Adjectives() ([]string, error) {
+	var adjs struct {
+		Adjectives []string
+	}
+
+	url := c.CopyURL + "/api/adjectives"
+	err := getJSON(c.Ctx, url, &adjs)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return adjs.Adjectives, nil
+}
+
+func (c CopyClient) Names() ([]string, error) {
+	var names struct {
+		Names []string
+	}
+
+	url := c.CopyURL + "/api/names"
+	err := getJSON(c.Ctx, url, &names)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return names.Names, nil
+}
+
+// getJSON performs an HTTP GET request to the specified URL and unmarshals the JSON-encoded body in dest.
+// If non-nil, user ID and trace IDs are sourced form rContext and propagated in the request.
+func getJSON(parentCtx context.Context, url string, dest any) error {
+	if parentCtx == nil {
+		parentCtx = context.TODO()
+	}
+
+	request, err := http.NewRequestWithContext(parentCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("building http request: %w", err)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+	resp, err := httpDoWithTracing(parentCtx, request)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	dec.DisallowUnknownFields()
+	err = dec.Decode(dest)
+	if err != nil {
+		return fmt.Errorf("reading response body into target: %w", err)
+	}
+
+	return nil
+}
+
+// getJSON performs an HTTP GET request to the specified URL and unmarshals the JSON-encoded body in dest.
+// If non-nil, user ID and trace IDs are sourced form rContext and propagated in the request.
+func postJSON(parentCtx context.Context, url string, src any) error {
+	if parentCtx == nil {
+		parentCtx = context.TODO()
+	}
+
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf).Encode(src)
+	if enc != nil {
+		return fmt.Errorf("encoding request: %w", enc)
+	}
+
+	request, err := http.NewRequestWithContext(parentCtx, http.MethodPost, url, buf)
+	if err != nil {
+		return fmt.Errorf("building http request: %w", err)
+	}
+
+	resp, err := httpDoWithTracing(parentCtx, request)
+	defer func() {
+		// Close body even if we do not care about it. This allows connection reuse but, more importantly, will cause
+		// the client trace to actually be sent, which wouldn't if the body is never read.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	return err
+}
+
+func httpDoWithTracing(rContext context.Context, request *http.Request) (*http.Response, error) {
+	// Authenticate request with the super-secret internal token.
+	request.Header.Add("X-Internal-Token", "secret")
+
+	if user, ok := rContext.Value("user").(string); ok {
+		request.Header.Add("X-User-ID", user)
+	}
+
+	client := &http.Client{
+		Transport: otelhttp.NewTransport(
+			nil,
+			// Propagator will retrieve the tracer used in the server from memory.
+			otelhttp.WithPropagators(propagation.TraceContext{}),
+		),
+	}
+
+	return client.Do(request)
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -223,7 +223,7 @@ func (s *Server) WithWS() *Server {
 	return s
 }
 
-// WithCatalog enables routes related to the ingredients, doughs, and tools. An database.InMemoryDatabase is required to
+// WithCatalog enables routes related to the ingredients, doughs, and tools. A database.InMemoryDatabase is required to
 // enable this endpoint group.
 // This database is safe to be used concurrently and thus may be shared with other endpoint groups.
 func (s *Server) WithCatalog(db *database.InMemoryDatabase) *Server {

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -566,8 +566,16 @@ func (s *Server) WithRecommendations(catalogUrl, copyUrl string) *Server {
 				return
 			}
 
+			_, pizzaSpan := trace.SpanFromContext(r.Context()).TracerProvider().Tracer("").Start(
+				r.Context(),
+				"pizza-generation",
+			)
 			var p pizza.Pizza
 			for i := 0; i < 10; i++ {
+				_, nameSpan := pizzaSpan.TracerProvider().Tracer("").Start(
+					r.Context(),
+					"name-generation",
+				)
 				var randomName string
 				for {
 					randomName = fmt.Sprintf("%s %s", adjectives[rand.Intn(len(adjectives))], names[rand.Intn(len(names))])
@@ -587,6 +595,7 @@ func (s *Server) WithRecommendations(catalogUrl, copyUrl string) *Server {
 						break
 					}
 				}
+				nameSpan.End()
 
 				p = pizza.Pizza{
 					Name:        randomName,
@@ -614,6 +623,7 @@ func (s *Server) WithRecommendations(catalogUrl, copyUrl string) *Server {
 
 				break
 			}
+			pizzaSpan.End()
 
 			pizzaRecommendation := PizzaRecommendation{
 				Pizza:      p,

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -257,16 +257,16 @@ func (s *Server) WithCatalog(db *database.InMemoryDatabase) *Server {
 			isVegetarian := r.URL.Query().Get("is_vegetarian")
 
 			var ingredients []pizza.Ingredient
-			db.Transaction(func(data *database.Data) {
+			db.Transaction(func(data database.Data) {
 				switch ingredientType {
 				case "olive_oil":
-					ingredients = append(ingredients, data.OliveOils...)
+					ingredients = data.OliveOils
 				case "tomato":
-					ingredients = append(ingredients, data.Tomatoes...)
+					ingredients = data.Tomatoes
 				case "mozzarella":
-					ingredients = append(ingredients, data.Mozzarellas...)
+					ingredients = data.Mozzarellas
 				case "topping":
-					ingredients = append(ingredients, data.Toppings...)
+					ingredients = data.Toppings
 				}
 			})
 
@@ -299,8 +299,8 @@ func (s *Server) WithCatalog(db *database.InMemoryDatabase) *Server {
 			logger.Info("Doughs requested")
 
 			var doughs []pizza.Dough
-			db.Transaction(func(data *database.Data) {
-				doughs = append(doughs, data.Doughs...)
+			db.Transaction(func(data database.Data) {
+				doughs = data.Doughs
 			})
 
 			err := json.NewEncoder(w).Encode(map[string][]pizza.Dough{"doughs": doughs})
@@ -316,8 +316,8 @@ func (s *Server) WithCatalog(db *database.InMemoryDatabase) *Server {
 			logger.Info("Tools requested")
 
 			var tools []string
-			db.Transaction(func(data *database.Data) {
-				tools = append(tools, data.Tools...)
+			db.Transaction(func(data database.Data) {
+				tools = data.Tools
 			})
 
 			err := json.NewEncoder(w).Encode(map[string][]string{"tools": tools})
@@ -434,8 +434,8 @@ func (s *Server) WithCopy(db *database.InMemoryDatabase) *Server {
 			logger.Info("Quotes requested")
 
 			var quotes []string
-			db.Transaction(func(data *database.Data) {
-				quotes = append(quotes, data.Quotes...)
+			db.Transaction(func(data database.Data) {
+				quotes = data.Quotes
 			})
 
 			err := json.NewEncoder(w).Encode(map[string][]string{"quotes": quotes})
@@ -451,8 +451,8 @@ func (s *Server) WithCopy(db *database.InMemoryDatabase) *Server {
 			logger.Info("Names requested")
 
 			var names []string
-			db.Transaction(func(data *database.Data) {
-				names = append(names, data.ClassicNames...)
+			db.Transaction(func(data database.Data) {
+				names = data.ClassicNames
 			})
 
 			err := json.NewEncoder(w).Encode(map[string][]string{"names": names})
@@ -468,8 +468,8 @@ func (s *Server) WithCopy(db *database.InMemoryDatabase) *Server {
 			logger.Info("Adjectives requested")
 
 			var adjs []string
-			db.Transaction(func(data *database.Data) {
-				adjs = append(adjs, data.Adjectives...)
+			db.Transaction(func(data database.Data) {
+				adjs = data.Adjectives
 			})
 
 			err := json.NewEncoder(w).Encode(map[string][]string{"adjectives": adjs})

--- a/pkg/pizza/pizza.go
+++ b/pkg/pizza/pizza.go
@@ -43,3 +43,17 @@ type Restrictions struct {
 	MaxNumberOfToppings int      `json:"maxNumberOfToppings"`
 	MinNumberOfToppings int      `json:"minNumberOfToppings"`
 }
+
+func (r Restrictions) WithDefaults() Restrictions {
+	if r.MaxCaloriesPerSlice == 0 {
+		r.MaxCaloriesPerSlice = 1000
+	}
+	if r.MaxNumberOfToppings == 0 {
+		r.MaxNumberOfToppings = 5
+	}
+	if r.MinNumberOfToppings == 0 {
+		r.MinNumberOfToppings = 3
+	}
+
+	return r
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -16,7 +16,7 @@ import (
 
 // OTLPProvider returns a TracerProvider configured to push traces to the given OTLP endpoint.
 // HTTP, HTTPS, or GRPC transport will be used depending on the scheme specified in endpointUrl.
-func OTLPProvider(ctx context.Context, endpointUrl string) (trace.TracerProvider, error) {
+func OTLPProvider(ctx context.Context, endpointUrl, serviceName string) (trace.TracerProvider, error) {
 	u, err := url.Parse(endpointUrl)
 	if err != nil {
 		return nil, fmt.Errorf("parsing endpoint url: %w", err)
@@ -43,7 +43,7 @@ func OTLPProvider(ctx context.Context, endpointUrl string) (trace.TracerProvider
 		resource.Default(),
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceName("QuickPizza"),
+			semconv.ServiceName(serviceName),
 		),
 	)
 	if err != nil {

--- a/pkg/web/src/routes/+page.svelte
+++ b/pkg/web/src/routes/+page.svelte
@@ -45,7 +45,14 @@
 			});
 		const json = await res.json();
 		quote = json.quotes[Math.floor(Math.random() * json.quotes.length)];
-		socket = new WebSocket(PUBLIC_BACKEND_WS_ENDPOINT + 'ws');
+
+		let wsUrl = `${PUBLIC_BACKEND_WS_ENDPOINT}`;
+		if (wsUrl === "") {
+			// Unlike with fetch, which understands "/" as "the window's host", for WS we need to build the URI by hand.
+			const l = window.location;
+			wsUrl = ((l.protocol === "https:") ? "wss://" : "ws://") + l.hostname + (((l.port != 80) && (l.port != 443)) ? ":" + l.port : "") + "/ws";
+		}
+		socket = new WebSocket(wsUrl);
 		socket.addEventListener('message', function (event) {
 			const data = JSON.parse(event.data);
 			if (data.msg === 'new_pizza') {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -126,8 +126,6 @@ go.opentelemetry.io/proto/otlp/trace/v1
 # go.uber.org/atomic v1.8.0
 ## explicit; go 1.13
 go.uber.org/atomic
-# go.uber.org/goleak v1.2.1
-## explicit; go 1.18
 # go.uber.org/multierr v1.7.0
 ## explicit; go 1.14
 go.uber.org/multierr


### PR DESCRIPTION
This PR provides a first implementation of splitting the backend into several components, which can be enabled together on a single service, leading to a monolith-like deployment; or enabled separately into several deployments, leading to a microservices-like deployment.

The following groups of API endpoints have been defined:
- Recommendations
  - `/api/pizza`
- Copy
  - `/api/names`
  - `/api/quotes`
  - `/api/adjectives`
- Catalog
  - `/api/ingredients/*`
  - `/api/doughs`
  - `/api/tools`
  - `/api/internal/recommendations` (GET and POST)
  - `/api/login` (WIP, may not end here)
- Websockets
  - `/ws`
- Frontend
  - `/` (Static Svelte files)

Additionaly, a homemade gateway has been developed. This gateway is automatically enabled together with the Frontend service if the application is deployed using microservices, and allows users to reach services other than the frontend from the browser.

Each of this groups can be deployed as a separate service, or arbitrarily together.

API groups (or services) communicate with each other using HTTP calls, e.g. the Recommendations service queries Catalog for the ingredients list and Copy for names and adjectives. It also POSTs recommendations to the catalog once served. These HTTP requests will take place even if the application is deployed as a single service, meaning the service will query itself. This allows keeping the code simple.

Remaining work:
- [x] Propagate trace ID across requests
- [x] Propagate user ID across requests
- [ ] Revisit admin authentication

![image](https://github.com/grafana/quickpizza/assets/969721/a737e5b1-80f5-47a6-94cb-3b0e5c44c8fa)

### Distributed tracing, yay!

![image](https://github.com/grafana/quickpizza/assets/969721/4088f92b-c98c-4631-9681-c2ce8a49d721)

