### PR TITLE
backend/http: allow to use custom clients with CatalogClient and CopyClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ echo $BASE_URL
 
 Distributed tracing support can be enabled when deploying in Kubernetes by editing the `kubernetes/kustomization.yaml` file and following the instructions in the comments present on that file. You will need a backend capable of ingesting OTLP traces, such as a Grafana Cloud Stack, or a Tempo deployment.
 
+After making the changes `kubernetes/kustomization.yaml`, you may need to restart the QuickPizza pods for them to pick up the new configuration:
+
+```shell
+kubectl delete pods -l app.k8s.io/name=quickpizza
+```
+
 ![Screenshot of a trace visualized in Grafana Tempo](https://github.com/grafana/quickpizza/assets/969721/4088f92b-c98c-4631-9681-c2ce8a49d721)
 
 ### Running xk6-disruptor tests

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,11 +33,6 @@ func main() {
 	// If no specific env vars are set, this will return a http client that does not perform any retries.
 	httpCli := clientFromEnv()
 
-	httpRequestTimeout := time.Duration(envInt("QUICKPIZZA_TIMEOUT_MS")) * time.Millisecond
-	if httpRequestTimeout == 0 {
-		httpRequestTimeout = 1000 * time.Millisecond
-	}
-
 	server, err := qphttp.NewServer(globalLogger)
 	if err != nil {
 		globalLogger.Fatal("Cannot create server", zap.Error(err))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/go-chi/chi v1.5.4
 	github.com/go-chi/cors v1.2.1
+	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/olahol/melody v1.1.3
 	github.com/prometheus/client_golang v1.14.1-0.20221122130035-8b6e68085b10
 	github.com/rs/xid v1.4.0
@@ -28,6 +29,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,12 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/k6/disruptor/02.error.js
+++ b/k6/disruptor/02.error.js
@@ -1,0 +1,58 @@
+import http from "k6/http";
+import {check, sleep} from "k6";
+import {ServiceDisruptor} from "k6/x/disruptor";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3333";
+
+const scenarios = {
+    disrupt: {
+        executor: "shared-iterations",
+        iterations: 1,
+        exec: "disrupt",
+    },
+    load: {
+        executor: "constant-vus",
+        vus: 5,
+        duration: "30s",
+        startTime: "5s",
+    },
+};
+
+if (__ENV.DISABLE_DISRUPT) {
+    delete scenarios["disrupt"];
+}
+
+export const options = {
+    scenarios: scenarios,
+};
+
+export function disrupt(data) {
+    const disruptor = new ServiceDisruptor("quickpizza-catalog", "default");
+    const targets = disruptor.targets();
+    if (targets.length === 0) {
+        throw new Error("expected list to have one target");
+    }
+
+    disruptor.injectHTTPFaults({errorRate: 0.1, errorCode: 503}, "40s");
+}
+
+export default function () {
+    const restrictions = {
+        "maxCaloriesPerSlice": 500,
+        "mustBeVegetarian": false,
+        "excludedIngredients": ["pepperoni"],
+        "excludedTools": ["knife"],
+        "maxNumberOfToppings": 6,
+        "minNumberOfToppings": 2
+    }
+
+    let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
+        headers: {
+            "Content-Type": "application/json",
+            "X-User-ID": 23423,
+        },
+    });
+    check(res, {"status is 200": (res) => res.status === 200});
+
+    sleep(1);
+}

--- a/kubernetes/grafana-agent/kustomization.yaml
+++ b/kubernetes/grafana-agent/kustomization.yaml
@@ -1,9 +1,11 @@
 resources:
   - ./resources/deployment.yaml
   - ./resources/service.yaml
-  - ./resources/quickpizza-env.yaml
 
 configMapGenerator:
   - name: agent-config
     files:
       - ./config/grafana-agent.river
+  - name: tracing-env
+    literals:
+      - QUICKPIZZA_OTLP_ENDPOINT=http://grafana-agent:4318

--- a/kubernetes/grafana-agent/resources/quickpizza-env.yaml
+++ b/kubernetes/grafana-agent/resources/quickpizza-env.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: otel-endpoint
-data:
-  QUICKPIZZA_OTLP_ENDPOINT: "http://grafana-agent:4318"

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -2,13 +2,13 @@
 #namespace: quickpizza
 
 resources:
-  - ./resources/deployments.yaml
-  - ./resources/services.yaml
+  - resources/deployments.yaml
+  - resources/services.yaml
   # Uncomment the line below if you want tracing functionality. This will deploy the grafana agent and configure
   # QuickPizza to push traces to it.
-  #- ./grafana-agent
+  #- grafana-agent
 
-# For full tracing functionality, change the following lines to match your OTLP endpoint and username/password.
+# For tracing functionality, change the following lines to match your OTLP endpoint and username/password.
 # For Grafana cloud, see https://grafana.com/docs/agent/latest/flow/getting-started/opentelemetry-to-lgtm-stack/#grafana-tempo
 secretGenerator:
   - name: grafana-agent-credentials
@@ -16,3 +16,9 @@ secretGenerator:
       - TRACES_ENDPOINT=your-tracing-endpoint.grafana.net:443
       - TRACES_USER=12345
       - TRACES_API_KEY=your-api-key
+
+# You can use the following generator to add additional environment variables to all QuickPizza pods.
+configMapGenerator:
+  - name: extra-env
+    literals: []
+    #- CUSTOM_ENV=CUSTOM_VALUE

--- a/kubernetes/resources/deployments.yaml
+++ b/kubernetes/resources/deployments.yaml
@@ -29,8 +29,10 @@ spec:
               containerPort: 3333
           envFrom:
             - configMapRef:
-                name: otel-endpoint
+                name: tracing-env
                 optional: true
+            - configMapRef:
+                name: extra-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -80,8 +82,10 @@ spec:
               containerPort: 3333
           envFrom:
             - configMapRef:
-                name: otel-endpoint
+                name: tracing-env
                 optional: true
+            - configMapRef:
+                name: extra-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -123,8 +127,10 @@ spec:
               containerPort: 3333
           envFrom:
             - configMapRef:
-                name: otel-endpoint
+                name: tracing-env
                 optional: true
+            - configMapRef:
+                name: extra-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -166,8 +172,10 @@ spec:
               containerPort: 3333
           envFrom:
             - configMapRef:
-                name: otel-endpoint
+                name: tracing-env
                 optional: true
+            - configMapRef:
+                name: extra-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -209,8 +217,10 @@ spec:
               containerPort: 3333
           envFrom:
             - configMapRef:
-                name: otel-endpoint
+                name: tracing-env
                 optional: true
+            - configMapRef:
+                name: extra-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -9,124 +9,24 @@ import (
 	"net/http"
 
 	"github.com/grafana/quickpizza/pkg/pizza"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 )
 
-// CatalogClient is a client that queries the Catalog service.
-type CatalogClient struct {
-	CatalogUrl     string
-	TracerProvider trace.TracerProvider
-	Ctx            context.Context
+// httpClient is a convenience wrapper for an HTTP client that GETs and POSTs JSON requests with QuickPizza-specifics.
+type httpClient struct {
+	client *http.Client
 }
 
-// WithRequestContext returns a copy of the CatalogClient that will use the supplied context.
-// This context should come from a http.Request, and if provided, CatalogClient will:
-// - Extract parent tracer and trace IDs from it and propagate it to the requests it makes.
-// - Extract the QuickPizza user ID from it and propagate it as well.
-func (c CatalogClient) WithRequestContext(ctx context.Context) CatalogClient {
-	c.Ctx = ctx
-	return c
-}
-
-func (c CatalogClient) Ingredients(ingredientType string) ([]pizza.Ingredient, error) {
-	var ingredients struct {
-		Ingredients []pizza.Ingredient
-	}
-
-	url := c.CatalogUrl + "/api/ingredients/" + ingredientType
-	err := getJSON(c.Ctx, url, &ingredients)
-	if err != nil {
-		return nil, fmt.Errorf("querying %s: %w", url, err)
-	}
-
-	return ingredients.Ingredients, nil
-}
-
-func (c CatalogClient) Tools() ([]string, error) {
-	var tools struct {
-		Tools []string
-	}
-	url := c.CatalogUrl + "/api/tools"
-	err := getJSON(c.Ctx, url, &tools)
-	if err != nil {
-		return nil, fmt.Errorf("querying %s: %w", url, err)
-	}
-
-	return tools.Tools, nil
-}
-
-func (c CatalogClient) Doughs() ([]pizza.Dough, error) {
-	var doughs struct {
-		Doughs []pizza.Dough
-	}
-	url := c.CatalogUrl + "/api/doughs"
-	err := getJSON(c.Ctx, url, &doughs)
-	if err != nil {
-		return nil, fmt.Errorf("querying %s: %w", url, err)
-	}
-
-	return doughs.Doughs, nil
-}
-
-func (c CatalogClient) RecordRecommendation(p pizza.Pizza) error {
-	return postJSON(c.Ctx, c.CatalogUrl+"/api/internal/recommendations", p)
-}
-
-// CopyClient is a client that queries the Copy service.
-type CopyClient struct {
-	CopyURL string
-	Ctx     context.Context
-}
-
-func (c CopyClient) WithRequestContext(ctx context.Context) CopyClient {
-	c.Ctx = ctx
-	return c
-}
-
-func (c CopyClient) Adjectives() ([]string, error) {
-	var adjs struct {
-		Adjectives []string
-	}
-
-	url := c.CopyURL + "/api/adjectives"
-	err := getJSON(c.Ctx, url, &adjs)
-	if err != nil {
-		return nil, fmt.Errorf("querying %s: %w", url, err)
-	}
-
-	return adjs.Adjectives, nil
-}
-
-func (c CopyClient) Names() ([]string, error) {
-	var names struct {
-		Names []string
-	}
-
-	url := c.CopyURL + "/api/names"
-	err := getJSON(c.Ctx, url, &names)
-	if err != nil {
-		return nil, fmt.Errorf("querying %s: %w", url, err)
-	}
-
-	return names.Names, nil
-}
-
-// getJSON performs an HTTP GET request to the specified URL and unmarshals the JSON-encoded body in dest.
-// If non-nil, user ID and trace IDs are sourced form rContext and propagated in the request.
-func getJSON(parentCtx context.Context, url string, dest any) error {
-	if parentCtx == nil {
-		parentCtx = context.TODO()
-	}
-
+// getJSON queries the specified URL, expecting a JSON response which gets unmarshalled in dest.
+// If present in parentCtx, trace id and QuickPizza user id are propagated in the request.
+// parentCtx may not be nil.
+func (hc httpClient) getJSON(parentCtx context.Context, url string, dest any) error {
 	request, err := http.NewRequestWithContext(parentCtx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("building http request: %w", err)
 	}
 
 	request.Header.Add("Content-Type", "application/json")
-	resp, err := httpDoWithTracing(parentCtx, request)
+	resp, err := hc.do(request)
 	if err != nil {
 		return err
 	}
@@ -150,13 +50,10 @@ func getJSON(parentCtx context.Context, url string, dest any) error {
 	return nil
 }
 
-// getJSON performs an HTTP GET request to the specified URL and unmarshals the JSON-encoded body in dest.
-// If non-nil, user ID and trace IDs are sourced form rContext and propagated in the request.
-func postJSON(parentCtx context.Context, url string, src any) error {
-	if parentCtx == nil {
-		parentCtx = context.TODO()
-	}
-
+// postJSON performs an HTTP POST request, marshalling src into the request body.
+// If present in parentCtx, trace id and QuickPizza user id are propagated in the request.
+// parentCtx may not be nil.
+func (hc httpClient) postJSON(parentCtx context.Context, url string, src any) error {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf).Encode(src)
 	if enc != nil {
@@ -168,7 +65,11 @@ func postJSON(parentCtx context.Context, url string, src any) error {
 		return fmt.Errorf("building http request: %w", err)
 	}
 
-	resp, err := httpDoWithTracing(parentCtx, request)
+	resp, err := hc.do(request)
+	if err != nil {
+		return fmt.Errorf("making http request: %w", enc)
+	}
+
 	defer func() {
 		// Close body even if we do not care about it. This allows connection reuse but, more importantly, will cause
 		// the client trace to actually be sent, which wouldn't if the body is never read.
@@ -180,24 +81,150 @@ func postJSON(parentCtx context.Context, url string, src any) error {
 		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 
-	return err
+	return nil
 }
 
-func httpDoWithTracing(rContext context.Context, request *http.Request) (*http.Response, error) {
+// do performs the supplied request.
+// The supplied request is expected to include on its context the k6 user.
+func (hc httpClient) do(request *http.Request) (*http.Response, error) {
 	// Authenticate request with the super-secret internal token.
 	request.Header.Add("X-Internal-Token", "secret")
 
-	if user, ok := rContext.Value("user").(string); ok {
+	// Propagate X-User-ID if present in request context.
+	if user, ok := request.Context().Value("user").(string); ok {
 		request.Header.Add("X-User-ID", user)
 	}
 
-	client := &http.Client{
-		Transport: otelhttp.NewTransport(
-			nil,
-			// Propagator will retrieve the tracer used in the server from memory.
-			otelhttp.WithPropagators(propagation.TraceContext{}),
-		),
+	return hc.client.Do(request)
+}
+
+// CatalogClient is a client that queries the Catalog service.
+type CatalogClient struct {
+	catalogUrl string
+	ctx        context.Context
+	client     httpClient
+}
+
+// NewCatalogClient returns a ready-to-use client for the QuickPizza catalog, service given its URL.
+func NewCatalogClient(url string) CatalogClient {
+	return CatalogClient{
+		catalogUrl: url,
+		ctx:        context.Background(),
+		client:     httpClient{client: http.DefaultClient},
+	}
+}
+
+// WithClient returns a CatalogClient that uses the specified http.Client, instead of http.DefaultClient.
+func (c CatalogClient) WithClient(client *http.Client) CatalogClient {
+	c.client = httpClient{client: client}
+	return c
+}
+
+// WithRequestContext returns a copy of the CatalogClient that will use the supplied context.
+// This context should come from a http.Request, and if provided, CatalogClient will:
+// - Extract parent tracer and trace IDs from it and propagate it to the requests it makes.
+// - Extract the QuickPizza user ID from it and propagate it as well.
+func (c CatalogClient) WithRequestContext(ctx context.Context) CatalogClient {
+	c.ctx = ctx
+	return c
+}
+
+func (c CatalogClient) Ingredients(ingredientType string) ([]pizza.Ingredient, error) {
+	var ingredients struct {
+		Ingredients []pizza.Ingredient
 	}
 
-	return client.Do(request)
+	url := c.catalogUrl + "/api/ingredients/" + ingredientType
+	err := c.client.getJSON(c.ctx, url, &ingredients)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return ingredients.Ingredients, nil
+}
+
+func (c CatalogClient) Tools() ([]string, error) {
+	var tools struct {
+		Tools []string
+	}
+	url := c.catalogUrl + "/api/tools"
+	err := c.client.getJSON(c.ctx, url, &tools)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return tools.Tools, nil
+}
+
+func (c CatalogClient) Doughs() ([]pizza.Dough, error) {
+	var doughs struct {
+		Doughs []pizza.Dough
+	}
+	url := c.catalogUrl + "/api/doughs"
+	err := c.client.getJSON(c.ctx, url, &doughs)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return doughs.Doughs, nil
+}
+
+func (c CatalogClient) RecordRecommendation(p pizza.Pizza) error {
+	return c.client.postJSON(c.ctx, c.catalogUrl+"/api/internal/recommendations", p)
+}
+
+// CopyClient is a client that queries the Copy service.
+type CopyClient struct {
+	copyURL string
+	ctx     context.Context
+	client  httpClient
+}
+
+// NewCopyClient is the Copy service equivalent of NewCatalogClient.
+func NewCopyClient(url string) CopyClient {
+	return CopyClient{
+		copyURL: url,
+		ctx:     context.Background(),
+		client:  httpClient{client: http.DefaultClient},
+	}
+}
+
+// WithClient is the Copy service equivalent of CatalogClient.
+func (c CopyClient) WithClient(client *http.Client) CopyClient {
+	c.client = httpClient{client: client}
+	return c
+}
+
+// WithRequestContext is the Copy service equivalent of CatalogClient.
+func (c CopyClient) WithRequestContext(ctx context.Context) CopyClient {
+	c.ctx = ctx
+	return c
+}
+
+func (c CopyClient) Adjectives() ([]string, error) {
+	var adjs struct {
+		Adjectives []string
+	}
+
+	url := c.copyURL + "/api/adjectives"
+	err := c.client.getJSON(c.ctx, url, &adjs)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return adjs.Adjectives, nil
+}
+
+func (c CopyClient) Names() ([]string, error) {
+	var names struct {
+		Names []string
+	}
+
+	url := c.copyURL + "/api/names"
+	err := c.client.getJSON(c.ctx, url, &names)
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", url, err)
+	}
+
+	return names.Names, nil
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -486,10 +486,7 @@ func (s *Server) WithCopy(db *database.InMemoryDatabase) *Server {
 
 // WithRecommendations enables the recommendations endpoint in this Server. This endpoint is stateless and thus needs
 // the URLs for the Catalog and Copy services.
-func (s *Server) WithRecommendations(catalogUrl, copyUrl string) *Server {
-	catalogClient := CatalogClient{CatalogUrl: catalogUrl}
-	copyClient := CopyClient{CopyURL: copyUrl}
-
+func (s *Server) WithRecommendations(catalogClient CatalogClient, copyClient CopyClient) *Server {
 	s.router.Group(func(r chi.Router) {
 		r.Use(func(handler http.Handler) http.Handler {
 			return otelhttp.NewHandler(

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,6 +40,12 @@ github.com/gorilla/websocket
 github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule
 github.com/grpc-ecosystem/grpc-gateway/v2/runtime
 github.com/grpc-ecosystem/grpc-gateway/v2/utilities
+# github.com/hashicorp/go-cleanhttp v0.5.2
+## explicit; go 1.13
+github.com/hashicorp/go-cleanhttp
+# github.com/hashicorp/go-retryablehttp v0.7.4
+## explicit; go 1.13
+github.com/hashicorp/go-retryablehttp
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil


### PR DESCRIPTION
This PR introduced some small changes to in-service HTTP clients, which allow to configure parameters such as the number of retries, backoff, etc.