### PR TITLE
backend/http: fix client shadowing that caused trace scrambling

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -516,8 +516,8 @@ func (s *Server) WithRecommendations(catalogUrl, copyUrl string) *Server {
 			// by the server (if any), which allows clients to both generate traces for outgoing client-type traces
 			// without explicitly configuring a tracer, and to link said client traces with the server trace that is
 			// generated in this request.
-			catalogClient = catalogClient.WithRequestContext(r.Context())
-			copyClient = copyClient.WithRequestContext(r.Context())
+			catalogClient := catalogClient.WithRequestContext(r.Context())
+			copyClient := copyClient.WithRequestContext(r.Context())
 
 			logger := loggerWithUserID(s.log, r)
 			logger.Info("Received pizza recommendation request")


### PR DESCRIPTION
I submit this PR as an acknowledgement that it has been `0` days since the last time that Go's variable shadowing in lambdas made me waste 1 hour debugging. Fool me once, same on you; fool me 27 times, shame on me.

This PR fixes a bug where the contextualized clients were overriding each other, instead of being contextualized per each request.
This caused traces to be scrambled when two requests were processed in parallel, with their parents mixed up.
