### PR TITLE
backend/http: fix calculation of number of toppings

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -658,7 +658,13 @@ func (s *Server) WithRecommendations(catalogClient CatalogClient, copyClient Cop
 					Tool:        validTools[rand.Intn(len(validTools))],
 				}
 
-				for j := 0; j < rand.Intn(restrictions.MaxNumberOfToppings-restrictions.MinNumberOfToppings)+restrictions.MinNumberOfToppings; j++ {
+				// Compute how many extra toppings we are allowed to add. If any, randomize that number.
+				extraToppings := restrictions.MaxNumberOfToppings - restrictions.MinNumberOfToppings
+				if extraToppings > 0 {
+					extraToppings = rand.Intn(extraToppings + 1)
+				}
+
+				for j := 0; j < extraToppings+restrictions.MinNumberOfToppings; j++ {
 					p.Ingredients = append(p.Ingredients, validToppings[rand.Intn(len(validToppings))])
 				}
 


### PR DESCRIPTION
Quick fix for the bug we saw recently on a demo, where the server would panic if the max number of toppings equals the min. Turns out the semantics of `rand.Intn` are not as obvious as one might think.