### PR TITLE
k6: use camelCase to encode ingredient restrictions

### DIFF
--- a/k6/foundations/01.basic.js
+++ b/k6/foundations/01.basic.js
@@ -10,12 +10,12 @@ export const options = {
 
 export default function () {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/02.stages.js
+++ b/k6/foundations/02.stages.js
@@ -13,12 +13,12 @@ export const options = {
 
 export default function () {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/03.lifecycle.js
+++ b/k6/foundations/03.lifecycle.js
@@ -20,12 +20,12 @@ export function setup() {
 
 export default function () {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/04.metrics.js
+++ b/k6/foundations/04.metrics.js
@@ -24,12 +24,12 @@ export function setup() {
 
 export default function () {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/05.thresholds.js
+++ b/k6/foundations/05.thresholds.js
@@ -29,12 +29,12 @@ export function setup() {
 
 export default function () {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/06.summary.js
+++ b/k6/foundations/06.summary.js
@@ -30,12 +30,12 @@ export function setup() {
 
 export default function () {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/07.scenarios.js
+++ b/k6/foundations/07.scenarios.js
@@ -44,12 +44,12 @@ export function setup() {
 
 export function getPizza() {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/08.data.js
+++ b/k6/foundations/08.data.js
@@ -49,12 +49,12 @@ export function setup() {
 
 export function getPizza() {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/09.composability.js
+++ b/k6/foundations/09.composability.js
@@ -56,12 +56,12 @@ export function setup() {
 
 export function getPizza() {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/10.library.js
+++ b/k6/foundations/10.library.js
@@ -56,12 +56,12 @@ export function setup() {
 
 export function getPizza() {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/11.extension.js
+++ b/k6/foundations/11.extension.js
@@ -57,12 +57,12 @@ export function setup() {
 
 export function getPizza() {
   let restrictions = {
-    max_calories_pers_slice: 500,
-    must_be_vegetarian: false,
-    excluded_ingredients: ["pepperoni"],
-    excluded_tools: ["knife"],
-    max_number_of_toppings: 6,
-    min_number_of_toppings: 2
+    maxCaloriesPerSlice: 500,
+    mustBeVegetarian: false,
+    excludedIngredients: ["pepperoni"],
+    excludedTools: ["knife"],
+    maxNumberOfToppings: 6,
+    minNumberOfToppings: 2
   }
   let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
     headers: {

--- a/k6/foundations/extension/main.go
+++ b/k6/foundations/extension/main.go
@@ -19,12 +19,12 @@ type Internal struct {
 }
 
 type GojaRestrictions struct {
-	MaxCaloriesPerSlice int      `json:"max_calories_per_slice"`
-	MustBeVegetarian    bool     `json:"must_be_vegetarian"`
-	ExcludedIngredients []string `json:"excluded_ingredients"`
-	ExcludedTools       []string `json:"excluded_tools"`
-	MinNumberOfToppings int      `json:"min_number_of_toppings"`
-	MaxNumberOfToppings int      `json:"max_number_of_toppings"`
+	MaxCaloriesPerSlice int      `json:"maxCaloriesPerSlice"`
+	MustBeVegetarian    bool     `json:"mustBeVegetarian"`
+	ExcludedIngredients []string `json:"excludedIngredients"`
+	ExcludedTools       []string `json:"excludedTools"`
+	MinNumberOfToppings int      `json:"minNumberOfToppings"`
+	MaxNumberOfToppings int      `json:"maxNumberOfToppings"`
 }
 
 // CheckRestrictions checks if the given pizza satisfies the given restrictions.


### PR DESCRIPTION
In #9  we made a change to the backend to format JSON keys as `camelCase`, as the frontend was sending them in camel case. However, k6 scripts were sending sneak_case instead.

This PR changes k6 script to use camel case as well.