### PR TITLE
Deploy trusting client-provided trace IDs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ docker network create quickpizza
 # Run the grafana agent. The provided config is not kubernetes-specific and works in Docker as well.
 docker run --name grafana-agent --rm -i -v ./kubernetes/grafana-agent/config/grafana-agent.river:/grafana-agent.river --network quickpizza -e TRACES_ENDPOINT -e TRACES_USER -e TRACES_API_KEY -e AGENT_MODE=flow grafana/agent run /grafana-agent.river
 # On a different terminal, run the QuickPizza container on the same network with tracing enabled:
-docker run --rm -i -p 3333:3333 -e QUICKPIZZA_OTLP_ENDPOINT=http://grafana-agent:4318 --network quickpizza ghcr.io/grafana/quickpizza-local:latest
+docker run --rm -i -p 3333:3333 -e QUICKPIZZA_OTLP_ENDPOINT=http://grafana-agent:4318 -e QUICKPIZZA_TRUST_CLIENT_TRACEID=1 --network quickpizza ghcr.io/grafana/quickpizza-local:latest
 ```
+
+The `QUICKPIZZA_TRUST_CLIENT_TRACEID` environment variable instructs QuickPizza to trust client-provided Trace IDs, so all client-generated spans (if any) will show up in the trace.
 
 ## Deploy application to Kubernetes
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,7 +56,7 @@ func main() {
 
 		server = server.WithTracing(tp)
 
-		if envBool("QUICKPIZZA_TRACING_INSECURE") {
+		if envBool("QUICKPIZZA_TRUST_CLIENT_TRACEID") {
 			server = server.WithInsecureTraceContext()
 		}
 	}

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -19,6 +19,9 @@ secretGenerator:
 
 # You can use the following generator to add additional environment variables to all QuickPizza pods.
 configMapGenerator:
-  - name: extra-env
-    literals: []
-    #- CUSTOM_ENV=CUSTOM_VALUE
+  - name: quickpizza-env
+    literals:
+      # Trust all incoming TraceIDs for demo purposes.
+      - QUICKPIZZA_TRUST_CLIENT_TRACEID=true
+      # You can change other settings by adding entries to this list:
+      #- CUSTOM_ENV=CUSTOM_VALUE

--- a/kubernetes/resources/deployments.yaml
+++ b/kubernetes/resources/deployments.yaml
@@ -32,7 +32,7 @@ spec:
                 name: tracing-env
                 optional: true
             - configMapRef:
-                name: extra-env
+                name: quickpizza-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -85,7 +85,7 @@ spec:
                 name: tracing-env
                 optional: true
             - configMapRef:
-                name: extra-env
+                name: quickpizza-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -130,7 +130,7 @@ spec:
                 name: tracing-env
                 optional: true
             - configMapRef:
-                name: extra-env
+                name: quickpizza-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -175,7 +175,7 @@ spec:
                 name: tracing-env
                 optional: true
             - configMapRef:
-                name: extra-env
+                name: quickpizza-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"
@@ -220,7 +220,7 @@ spec:
                 name: tracing-env
                 optional: true
             - configMapRef:
-                name: extra-env
+                name: quickpizza-env
           env:
             - name: QUICKPIZZA_ALL_SERVICES
               value: "0"


### PR DESCRIPTION
#19 introduced an environment variable that, when set, instructs QuickPizza to trust TraceIDs arriving to user-accessible endpoints, instead of generating new ones.

This PR enables this behavior by default, which is very reasonable for demo purposes. Moreover, the variable has also been renamed to `QUICKPIZZA_TRUST_CLIENT_TRACEID`, which hopefully will convey the same meaning while being slightly less alarming to see in the Docker CLI.