### PR TITLE
fix: pass correct writer to downstream

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -775,9 +775,9 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(ww, r)
 		duration := time.Since(start)
-		httpRequests.WithLabelValues(r.Method, r.URL.Path, http.StatusText(ww.Status())).Inc()
-		httpRequestDuration.WithLabelValues(r.Method, r.URL.Path, http.StatusText(ww.Status())).Observe(duration.Seconds())
+		httpRequests.WithLabelValues(r.Method, r.URL.Path, strconv.Itoa(ww.Status())).Inc()
+		httpRequestDuration.WithLabelValues(r.Method, r.URL.Path, strconv.Itoa(ww.Status())).Observe(duration.Seconds())
 	})
 }


### PR DESCRIPTION
This correctly records the status code in metric labels. I've also changed it to use the number instead of text since this allows better queries e.g. `{status=~"2.."}`