### PR TITLE
refactor: use agent docker component instead of loki driver

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -11,8 +11,3 @@ GRAFANA_CLOUD_STACK=GRAFANA_CLOUD_STACK_NAME
 # Access policy Token
 # Required scopes: `stacks:read`, `metrics:write`, `logs:write`, `traces:write`, `profiles:write`
 GRAFANA_CLOUD_TOKEN=GRAFANA_CLOUD_TOKEN
-
-# Loki User for basic authentication
-GRAFANA_CLOUD_LOKI_USER=GRAFANA_CLOUD_LOKI_USER
-# Host name of the Loki URL connection
-GRAFANA_CLOUD_LOKI_HOST=logs-prod-XYZ.grafana.net

--- a/README.md
+++ b/README.md
@@ -82,14 +82,6 @@ To run the test that uses the `k6/x/internal` module, use  previously created k6
 
 Testing something you can't observe is only half the fun. QuickPizza is instrumented using best practices to record logs, emit metrics, traces and allow profiling. You can either collect and [store this data locally](#local-setup) or send it to [Grafana Cloud](#grafana-cloud).
 
-First, we need to install the [Loki docker plugin](https://grafana.com/docs/loki/latest/send-data/docker-driver/) to be able to read the logs from the QuickPizza container. Run the following command, updating the release version if needed:
-
-```bash
-docker plugin install grafana/loki-docker-driver:2.9.1 --alias loki --grant-all-permissions
-```
-
-> Note that Docker plugins are not supported on Windows, meaning QuickPizza logs won't be sent to Loki with the Docker Compose setup. When executing `docker compose up` on Windows, either pass the env. variable: `LOGGING_DRIVER=none`, or remove the `services/quickpizza/logging` section from the `docker-compose-*.yaml` files.
-
 ## Enabling debug logging
 
 If you encounter any issues during operation, you can enable debug logging by setting the following evironment variable:
@@ -104,10 +96,9 @@ export QUICKPIZZA_LOG_LEVEL=debug
 
 The [docker-compose-local.yaml](./docker-compose-local.yaml) file is set up to run and orchestrate the QuickPizza, Grafana, Tempo, Loki, Prometheus, Pyroscope, and Grafana Agent containers.
 
-The Grafana Agent collects traces, metrics, and profiling data from the QuickPizza app, forwarding them to the Tempo, Prometheus, and Pyroscope services. The Loki Docker plugin reads the logs and forwards them to the Loki service. Finally, you can visualize and correlate data stored in these containers with the locally running Grafana instance. 
+The Grafana Agent collects traces, metrics, logs and profiling data from the QuickPizza app, forwarding them to the Tempo, Prometheus, Loki and Pyroscope services. Finally, you can visualize and correlate data stored in these containers with the locally running Grafana instance. 
 
-
-First, if you haven't done so in the previous step, install the `Loki Docker plugin`. To start the local environment, use the following command:
+To start the local environment, use the following command:
 
 ```bash
 docker compose -f docker-compose-local.yaml up -d

--- a/README.md
+++ b/README.md
@@ -145,18 +145,15 @@ In this setup, the Grafana Agent collects observability data from the QuickPizza
 You will need the following settings:
 1. The name of the [Grafana Cloud Stack](https://grafana.com/docs/grafana-cloud/account-management/cloud-portal/#your-grafana-cloud-stack) where the telemetry data will be stored. 
 2. An [Access Policy Token](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) that includes the following scopes for the selected Grafana Cloud Stack: `stacks:read`, `metrics:write`, `logs:write`, `traces:write`, and `profiles:write`.
-3. Loki user and Loki host for basic authentication. Navigate to the Grafana Cloud Stack on the [Cloud Portal](https://grafana.com/docs/grafana-cloud/fundamentals/cloud-portal/) and click the Loki `Details`. 
 
 Then, create an `.env` file with the following environment variables and the values of the previous settings:
 
 ```bash
 GRAFANA_CLOUD_STACK=name
 GRAFANA_CLOUD_TOKEN=
-GRAFANA_CLOUD_LOKI_USER=123456
-GRAFANA_CLOUD_LOKI_HOST=logs-prod-XYZ.grafana.net
 ```
 
-Before running Docker Compose, install the `Loki Docker plugin` if you haven't done so previously. Finally, execute the Docker Compose command using the `docker-compose-cloud.yaml` file, just as in the local setup:
+Finally, execute the Docker Compose command using the `docker-compose-cloud.yaml` file, just as in the local setup:
 
 ```bash
 docker compose -f docker-compose-cloud.yaml up -d

--- a/contrib/agent-cloud.river
+++ b/contrib/agent-cloud.river
@@ -59,6 +59,7 @@ discovery.relabel "quickpizza" {
     source_labels = [
       "__meta_docker_container_name",
     ]
+    regex ="/(.*)"
     action = "replace"
   }
   rule {

--- a/contrib/agent-cloud.river
+++ b/contrib/agent-cloud.river
@@ -50,6 +50,34 @@ pyroscope.scrape "scrape_profiles" {
   ]
 }
 
+discovery.docker "all_containers" {
+  host = "unix:///var/run/docker.sock"
+}
+discovery.relabel "quickpizza" {
+  rule {
+    target_label = "instance"
+    source_labels = [
+      "__meta_docker_container_name",
+    ]
+    action = "replace"
+  }
+  rule {
+    target_label = "job"
+    source_labels = [
+      "__meta_docker_container_label_com_docker_compose_project",
+    ]
+    regex = ".*quickpizza.*"
+    action = "keep"
+  }
+  targets = discovery.docker.all_containers.targets
+}
+
+loki.source.docker "default" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.quickpizza.output
+  forward_to = [module.git.grafana_cloud.exports.logs_receiver]
+}
+
 module.git "grafana_cloud" {
   repository = "https://github.com/grafana/agent-modules.git"
   path = "modules/grafana-cloud/autoconfigure/module.river"

--- a/contrib/agent-cloud.river
+++ b/contrib/agent-cloud.river
@@ -53,6 +53,7 @@ pyroscope.scrape "scrape_profiles" {
 discovery.docker "all_containers" {
   host = "unix:///var/run/docker.sock"
 }
+
 discovery.relabel "quickpizza" {
   rule {
     target_label = "instance"

--- a/contrib/agent-local.river
+++ b/contrib/agent-local.river
@@ -77,3 +77,39 @@ pyroscope.write "default" {
     url = env("PROFILES_ENDPOINT")
   }
 }
+
+discovery.docker "all_containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "quickpizza" {
+  rule {
+    target_label = "instance"
+    source_labels = [
+      "__meta_docker_container_name",
+    ]
+    regex ="/(.*)"
+    action = "replace"
+  }
+  rule {
+    target_label = "job"
+    source_labels = [
+      "__meta_docker_container_label_com_docker_compose_project",
+    ]
+    regex = ".*quickpizza.*"
+    action = "keep"
+  }
+  targets = discovery.docker.all_containers.targets
+}
+
+loki.source.docker "default" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.quickpizza.output
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = env("LOGS_ENDPOINT")
+  }
+}

--- a/docker-compose-cloud.yaml
+++ b/docker-compose-cloud.yaml
@@ -5,18 +5,6 @@ services:
     # The QUICKPIZZA_IMAGE env. variable enables the use of a locally built image,
     # created with `docker build -t image_name .`
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest}
-    logging:
-      driver: ${LOGGING_DRIVER:-loki}
-      options:
-        loki-url: "https://${GRAFANA_CLOUD_LOKI_USER}:${GRAFANA_CLOUD_TOKEN}@${GRAFANA_CLOUD_LOKI_HOST}/loki/api/v1/push"
-        loki-relabel-config: |
-          - action: replace
-            source_labels: ["compose_service"]
-            separator: "/"
-            target_label: job
-          - action: replace
-            source_labels: ["container_name"]
-            target_label: instance
     ports:
       - "3333:3333"
     environment:
@@ -28,11 +16,11 @@ services:
   agent:
     image: grafana/agent:latest
     volumes:
-      - "./contrib/agent-cloud.river:/grafana-agent.river:Z"
-    command: [
-      "run",
-      "/grafana-agent.river",
-    ]
+      - "./contrib/agent-cloud.river:/grafana-agent.river"
+      - "${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock"
+    command: ["run", "/grafana-agent.river","--server.http.listen-addr=0.0.0.0:12345"]
+    ports:
+      - "12345:12345"
     environment:
       AGENT_MODE: flow
       QUICKPIZZA_HOST: quickpizza:3333

--- a/docker-compose-cloud.yaml
+++ b/docker-compose-cloud.yaml
@@ -16,9 +16,9 @@ services:
   agent:
     image: grafana/agent:latest
     volumes:
-      - "./contrib/agent-cloud.river:/grafana-agent.river"
+      - "./contrib/agent-cloud.river:/grafana-agent.river:Z"
       - "${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock"
-    command: ["run", "/grafana-agent.river","--server.http.listen-addr=0.0.0.0:12345"]
+    command: ["run", "/grafana-agent.river", "--server.http.listen-addr=0.0.0.0:12345"]
     ports:
       - "12345:12345"
     environment:

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -6,18 +6,6 @@ services:
     # The QUICKPIZZA_IMAGE env. variable enables the use of a locally built image,
     # created with `docker build -t image_name .`
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest}
-    logging:
-      driver: ${LOGGING_DRIVER:-loki}
-      options:
-        loki-url: http://localhost:3100/loki/api/v1/push
-        loki-relabel-config: |
-          - action: replace
-            source_labels: ["namespace","compose_service"]
-            separator: "/"
-            target_label: job
-          - action: replace
-            source_labels: ["container_name"]
-            target_label: instance
     ports:
       - "3333:3333"
     environment:
@@ -71,15 +59,16 @@ services:
     image: grafana/agent:latest
     volumes:
       - "./contrib/agent-local.river:/grafana-agent.river:Z"
-    command: [
-      "run",
-      "/grafana-agent.river",
-    ]
+      - "${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock"
+    command: ["run", "/grafana-agent.river", "--server.http.listen-addr=0.0.0.0:12345"]
+    ports:
+      - "12345:12345"
     environment:
       AGENT_MODE: flow
       QUICKPIZZA_HOST: quickpizza:3333
       METRICS_ENDPOINT: http://prometheus:9090/api/v1/write
       TRACES_ENDPOINT: http://tempo:4317
+      LOGS_ENDPOINT: http://loki:3100/loki/api/v1/push
       PROFILES_ENDPOINT: http://pyroscope:4040
     depends_on:
       - prometheus


### PR DESCRIPTION
This further simplifies configuration for first time users by:

* Removing the need to fetch the loki information from Grafana Cloud
* Removing the need to install the loki docker driver

I've only tested this with podman, would be great if someone can test this with a docker setup as well