### PR TITLE
web/faro: check for truthyness of faro_url instead of just presence

### DIFF
--- a/pkg/web/src/hooks.client.ts
+++ b/pkg/web/src/hooks.client.ts
@@ -7,7 +7,7 @@ function setupFaro() {
     then(data => data.json()).
     then(config => {
         const url = config.faro_url;
-        if (url === undefined) {
+        if (!url) {
             console.warn("Grafana faro is not configured.")
             return
         }


### PR DESCRIPTION
This will cause faro initialization to be skipped if the backend returns an empty url, which can happen if the env var `QUICKPIZZA_CONF_FARO_URL` is defined but empty.