### PR TITLE
Store and retrieve admin token from browser cookies

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -333,6 +333,12 @@ func (s *Server) WithCatalog(db *database.Catalog) *Server {
 			s.log.InfoContext(r.Context(), "Recommendations requested")
 			token := r.Header.Get("Authorization")
 			if token == "" {
+				if tokenCookie, err := r.Cookie("admin_token"); err == nil {
+					token = tokenCookie.Value
+				}
+			}
+
+			if token == "" {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -400,10 +400,18 @@ func (s *Server) WithCatalog(db *database.Catalog) *Server {
 
 			guid := xid.New()
 			token := guid.String()
-			//if s.db.userSessionTokens == nil {
-			//	s.db.userSessionTokens = make(map[string]time.Time)
-			//}
-			//s.db.userSessionTokens[token] = time.Now()
+			// TODO: Develop an authentication microservice. Perhaps overengineer it with JWT.
+			// if s.db.userSessionTokens == nil {
+			// 	s.db.userSessionTokens = make(map[string]time.Time)
+			// }
+			// s.db.userSessionTokens[token] = time.Now()
+
+			http.SetCookie(w, &http.Cookie{
+				Name:     "admin_token",
+				Value:    token,
+				SameSite: http.SameSiteStrictMode,
+				Path:     "/", // Required for /admin to be able to use a cookie returned by /api.
+			})
 			err := json.NewEncoder(w).Encode(map[string]string{"token": token})
 			if err != nil {
 				s.log.ErrorContext(r.Context(), "Failed to encode response", "err", err)

--- a/pkg/web/src/routes/admin/+page.svelte
+++ b/pkg/web/src/routes/admin/+page.svelte
@@ -14,25 +14,39 @@ onMount(async () => {
         if (user === 0) {
             userID.set(Math.floor(100000 + Math.random() * 900000));
         }
+
+        token = tokenFromCookie();
 });
+
+function tokenFromCookie() {
+    const tokenCookie = document.cookie.split("; ").filter(c => c.startsWith("admin_token"));
+    if (tokenCookie.length == 0) {
+        return "";
+    }
+
+    return tokenCookie[0].split("=")[1];
+}
 
 async function handleSubmit() {
     const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}api/login?user=admin&password=${password}`, {
 			method: 'GET',
             headers: {
 					'X-User-ID': user.toString()
-			}
+			},
+      credentials: 'same-origin', // Honor Set-Cookie header returned by /api/login.
 	},);
     if (!res.ok) {
         loginError = 'Login failed: ' + res.statusText;
         return;
     }
-	const json = await res.json();
-    token = json.token;
+
+    token = tokenFromCookie();
 }
 
 async function handleLogout() {
-    token = '';
+    // Perhaps surprisingly, this only deletes (clears the value of) the admin_token cookie.
+    document.cookie = "admin_token=; Expires=Thu, 01 Jan 1970 00:00:01 GMT";
+    token = "";
 }
 
 $: if (token) {


### PR DESCRIPTION
Prior to this PR, the token returned by `/api/login` was persisted only in the component state, which caused it to be lost when navigating away from the `/admin` page.

This PR makes the following changes to persist the admin token:

1. The `/api/login` endpoint now returns the token as a cookie in addition to as a json object in the response payload.
2. The `/admin` page now processes the cookies sent back by the server. The payload is now ignored.
3. The `/admin` page will attempt to load the token from cookie storage if it is present, and allow deleting the cookie with the logout button.
4. The `/api/internal/recommendations` allows reading the token from a cookie. This is currently not used by the frontend, which still sends the admin token using the `Authorization` header.

There is probably an argument to be made that we could get rid of cookies entirely and persist things in localStorage, but I thought using cookies might allow for http-only (i.e. no javascript) tests, if that makes sense.