### PR TITLE
Inject Pyroscope middleware into the call chain

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -145,7 +145,7 @@ func (s *Server) WithPrometheus() *Server {
 
 // WithProfiling adds a middleware that extracts k6 labels from the baggage and adds them to the context.
 func (s *Server) WithProfiling() *Server {
-	s.router.Use(k6.LabelsFromBaggageHandler)
+	s.router = s.router.With(k6.LabelsFromBaggageHandler)
 
 	return s
 }


### PR DESCRIPTION
This PR updates Pyroscope instrumentation to allow it to be called after a route has already been registered.