### PR TITLE
Add Pyroscope dashboard

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -45,7 +45,7 @@ services:
       - "4318:4318"
 
   grafana:
-    image: grafana/grafana:10.1.2
+    image: grafana/grafana:11.1.1
     ports:
       - "3000:3000"
     environment:

--- a/grafana/dashboards/definitions/pyroscope.json
+++ b/grafana/dashboards/definitions/pyroscope.json
@@ -1,0 +1,339 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PYROSCOPE",
+      "label": "Pyroscope",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-pyroscope-datasource",
+      "pluginName": "Grafana Pyroscope"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "flamegraph",
+      "name": "Flame Graph",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.1.2"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-pyroscope-datasource",
+      "name": "Grafana Pyroscope",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Visualize CPU profiles collected with Pyroscope",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "panels": [],
+      "title": "CPU",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "${DS_PYROSCOPE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": ["cpu"],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "${DS_PYROSCOPE}"
+          },
+          "groupBy": ["hostname"],
+          "labelSelector": "{service_name=~\"$service\", k6_test_run_id=~\"$testid\", k6_name=~\"$name\", k6_scenario=~\"$scenario\"}",
+          "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "${DS_PYROSCOPE}"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "${DS_PYROSCOPE}"
+          },
+          "groupBy": ["hostname"],
+          "labelSelector": "{service_name=~\"$service\", k6_test_run_id=~\"$testid\", k6_name=~\"$name\", k6_scenario=~\"$scenario\"}",
+          "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+          "queryType": "profile",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Flamegraph",
+      "type": "flamegraph"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["pyroscope", "k6"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-pyroscope-datasource",
+          "uid": "${DS_PYROSCOPE}"
+        },
+        "definition": "label_values(service_name)",
+        "error": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Service",
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "labelName": "service_name",
+          "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+          "type": "labelValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-pyroscope-datasource",
+          "uid": "${DS_PYROSCOPE}"
+        },
+        "definition": "label_values(k6_test_run_id)",
+        "error": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Test ID",
+        "multi": false,
+        "name": "testid",
+        "options": [],
+        "query": {
+          "labelName": "k6_test_run_id",
+          "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+          "type": "labelValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-pyroscope-datasource",
+          "uid": "${DS_PYROSCOPE}"
+        },
+        "definition": "label_values(k6_name)",
+        "error": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Test Name",
+        "multi": false,
+        "name": "name",
+        "options": [],
+        "query": {
+          "labelName": "k6_name",
+          "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+          "type": "labelValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-pyroscope-datasource",
+          "uid": "${DS_PYROSCOPE}"
+        },
+        "definition": "label_values(k6_scenario)",
+        "error": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Scenario",
+        "multi": false,
+        "name": "scenario",
+        "options": [],
+        "query": {
+          "labelName": "k6_scenario",
+          "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+          "type": "labelValue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Pyroscope",
+  "uid": "be627e9d-4851-42e7-b371-ddbe72e7c710",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/dashboards/definitions/pyroscope.json
+++ b/grafana/dashboards/definitions/pyroscope.json
@@ -225,6 +225,26 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "pyroscope",
+          "value": "${DS_PYROSCOPE}"
+        },
+        "description": "Choose a Pyroscope Data Source",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pyroscope DS",
+        "multi": false,
+        "name": "DS_PYROSCOPE",
+        "options": [],
+        "query": "grafana-pyroscope-datasource",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "grafana-pyroscope-datasource",

--- a/grafana/datasources/datasource.yaml
+++ b/grafana/datasources/datasource.yaml
@@ -1,4 +1,4 @@
-# For configuration options, see 
+# For configuration options, see
 #   https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
 
 apiVersion: 1
@@ -27,16 +27,18 @@ datasources:
     apiVersion: 1
     uid: tempo
   - name: Pyroscope
-    type: 'phlare'
-    access: 'proxy'
+    type: grafana-pyroscope-datasource
+    access: proxy
     orgId: 1
     uid: pyroscope
     url: http://pyroscope:4040
     isDefault: false
     editable: false
+    jsonData:
+      minStep: "15s"
   - name: Loki
     type: loki
-    access: proxy 
+    access: proxy
     orgId: 1
     url: http://loki:3100
     basicAuth: false


### PR DESCRIPTION
This PR bumps local Grafana version to 11.1.1 and adds a new dashboard that displays profile data to be provisioned on start.