### PR TITLE
Allow specifying Custom Base URL in gRPC Test Script

### DIFF
--- a/k6/foundations/16.grpc.js
+++ b/k6/foundations/16.grpc.js
@@ -1,7 +1,7 @@
 import { Client, StatusOK } from 'k6/net/grpc';
 import { check, sleep } from 'k6';
 
-const BASE_URL = 'localhost:3334';
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3334';
 
 const client = new Client();
 client.load(['definitions'], '../../../proto/quickpizza.proto');


### PR DESCRIPTION
This Allow specifying Custom Base URL in gRPC Test Script, similar to the other Test Scripts.