### PR TITLE
Add Prometheus Middleware to Router to add HTTP Metrics

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -192,6 +192,8 @@ func (s *Server) WithLivenessProbes() *Server {
 
 // WithPrometheus adds a /metrics endpoint and instrument subsequently enabled groups with general http-level metrics.
 func (s *Server) WithPrometheus() *Server {
+	// Add MW with .With instead of .Use, as .Use does not allow registering MWs after routes.
+	s.router = s.router.With(PrometheusMiddleware)
 	s.router.Handle("/metrics", promhttp.Handler())
 
 	return s


### PR DESCRIPTION
Somewhere between v0.11.0 and v0.12.0 the HTTP Metrics in Prometheus (such as `http_request_duration_seconds_bucket` and `http_requests_total` were missing and no longer show.

It looks like the Router no longer had the Prometheus Middleware Included so it was not generating these.

This re-adds that configuration to generate the Metrics again.