### PR TITLE
 Add Missing Routes to Gateway Reverse Proxy for Admin UI

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -310,6 +310,8 @@ func (s *Server) AddGateway(catalogUrl, copyUrl, wsUrl, recommendationsUrl, conf
 				var u *url.URL
 				s.log.Debug("Reverse Proxy Request", "endpoint", request.In.URL.Path)
 				switch request.In.URL.Path {
+				case "/api/users/token/login":
+					u, _ = url.Parse(catalogUrl)
 				case "/api/quotes":
 					u, _ = url.Parse(copyUrl)
 				case "/api/tools":

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -308,15 +308,20 @@ func (s *Server) AddGateway(catalogUrl, copyUrl, wsUrl, recommendationsUrl, conf
 			Transport: otelTransport,
 			Rewrite: func(request *httputil.ProxyRequest) {
 				var u *url.URL
+				s.log.Debug("Reverse Proxy Request", "endpoint", request.In.URL.Path)
 				switch request.In.URL.Path {
 				case "/api/quotes":
 					u, _ = url.Parse(copyUrl)
 				case "/api/tools":
 					u, _ = url.Parse(catalogUrl)
+				case "/api/internal/recommendations":
+					u, _ = url.Parse(catalogUrl)
 				case "/api/pizza":
 					u, _ = url.Parse(recommendationsUrl)
 				case "/api/config":
 					u, _ = url.Parse(configUrl)
+				case "/api/admin/login":
+					u, _ = url.Parse(catalogUrl)
 				}
 
 				request.SetURL(u)

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -326,6 +326,8 @@ func (s *Server) AddGateway(catalogUrl, copyUrl, wsUrl, recommendationsUrl, conf
 					u, _ = url.Parse(configUrl)
 				case "/api/admin/login":
 					u, _ = url.Parse(catalogUrl)
+				default:
+					u, _ = url.Parse(catalogUrl)
 				}
 
 				request.SetURL(u)

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -314,6 +314,8 @@ func (s *Server) AddGateway(catalogUrl, copyUrl, wsUrl, recommendationsUrl, conf
 					u, _ = url.Parse(copyUrl)
 				case "/api/tools":
 					u, _ = url.Parse(catalogUrl)
+				case "/api/ratings":
+					u, _ = url.Parse(catalogUrl)
 				case "/api/internal/recommendations":
 					u, _ = url.Parse(catalogUrl)
 				case "/api/pizza":


### PR DESCRIPTION
 Add Missing Routes to Gateway Reverse Proxy for Admin UI.

Currently if you run QuickPizza in a Microserices deployment and try to login to the Admin UI, you get a 500 Error and in the logs, you see a Panic;

```text
quickpizza-frontend         | {"timestamp":"2025-03-27T09:10:28.702299014Z","level":"ERROR","httpRequest":{"url":"http://127.0.0.1:3333/api/admin/login?user=admin&password=admin","method":"GET","path":"/api/admin/login"},"traceID":"da5ef584c06172d8047b8ed8993e2a7d","stacktrace":"goroutine 23 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x5e\ngithub.com/go-chi/chi/v5/middleware.Recoverer.func1.1()\n\t/app/vendor/github.com/go-chi/chi/v5/middleware/recoverer.go:34 +0x9a\npanic({0xe5ce40?, 0x1861e00?})\n\t/usr/local/go/src/runtime/panic.go:770 +0x132\ngo.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()\n\t/app/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:398 +0x25\ngo.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00066d040, {0x0, 0x0, 0xc000259a40?})\n\t/app/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:436 +0xa82\npanic({0xe5ce40?, 0x1861e00?})\n\t/usr/local/go/src/runtime/panic.go:770 +0x132\nnet/http/httputil.rewriteRequestURL(0x1?, 0x1?)\n\t/usr/local/go/src/net/http/httputil/reverseproxy.go:270 +0x16\nnet/http/httputil.(*ProxyRequest).SetURL(0xc000616f10, 0x1?)\n\t/usr/local/go/src/net/http/httputil/reverseproxy.go:55 +0x1f\nmain.main.(*Server).AddGateway.func5.1(0xc000616f10)\n\t/app/pkg/http/http.go:323 +0x158\nnet/http/httputil.(*ReverseProxy).ServeHTTP(0xc00011e870, {0x1180390, 0xc000334f00}, 0xc000398240)\n\t/usr/local/go/src/net/http/httputil/reverseproxy.go:433 +0x907\ngithub.com/grafana/quickpizza/pkg/http.LogTraceID.func1({0x1180390, 0xc000334f00}, 0xc000398120)\n\t/app/pkg/http/tracing.go:30 +0x2dc\nnet/http.HandlerFunc.ServeHTTP(0x1181220?, {0x1180390?, 0xc000334f00?}, 0x1175168?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*Handler).ServeHTTP(0xc000135a40, {0x7f58fc8d18e0, 0xc000420840}, 0xc0002cdd40)\n\t/app/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:212 +0x1223\ngithub.com/go-chi/chi/v5.(*ChainHandler).ServeHTTP(0xc00017c5a0?, {0x7f58fc8d18e0?, 0xc000420840?}, 0xc000636a04?)\n\t/app/vendor/github.com/go-chi/chi/v5/chain.go:31 +0x26\ngithub.com/go-chi/chi/v5.(*Mux).routeHTTP(0xc00011c0c0, {0x7f58fc8d18e0, 0xc000420840}, 0xc0002cdd40)\n\t/app/vendor/github.com/go-chi/chi/v5/mux.go:459 +0x2e6\nnet/http.HandlerFunc.ServeHTTP(0xc00013e140?, {0x7f58fc8d18e0?, 0xc000420840?}, 0xc0002cdd40?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngithub.com/go-chi/cors.(*Cors).Handler-fm.(*Cors).Handler.func1({0x7f58fc8d18e0, 0xc000420840}, 0xc0002cdd40)\n\t/app/vendor/github.com/go-chi/cors/cors.go:228 +0x17e\nnet/http.HandlerFunc.ServeHTTP(0x411b7b?, {0x7f58fc8d18e0?, 0xc000420840?}, 0x7f594335df18?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngithub.com/go-chi/chi/v5/middleware.Recoverer.func1({0x7f58fc8d18e0?, 0xc000420840?}, 0x0?)\n\t/app/vendor/github.com/go-chi/chi/v5/middleware/recoverer.go:45 +0x78\nnet/http.HandlerFunc.ServeHTTP(0x411f25?, {0x7f58fc8d18e0?, 0xc000420840?}, 0x1862d01?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngithub.com/go-chi/chi/v5/middleware.Recoverer.func1({0x7f58fc8d18e0?, 0xc000420840?}, 0xc00049e510?)\n\t/app/vendor/github.com/go-chi/chi/v5/middleware/recoverer.go:45 +0x78\nnet/http.HandlerFunc.ServeHTTP(0x1865780?, {0x7f58fc8d18e0?, 0xc000420840?}, 0x9dd7d168d?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngithub.com/grafana/quickpizza/pkg/http.NewServer.RequestLogger.Handler.func3.1({0x7f58fc8d18e0, 0xc0004207c0}, 0xc0002cdb00)\n\t/app/vendor/github.com/go-chi/httplog/v2/httplog.go:111 +0x436\nnet/http.HandlerFunc.ServeHTTP(0x1181220?, {0x7f58fc8d18e0?, 0xc0004207c0?}, 0x1175168?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngithub.com/go-chi/chi/v5/middleware.RequestID.func1({0x7f58fc8d18e0, 0xc0004207c0}, 0xc0002cd9e0)\n\t/app/vendor/github.com/go-chi/chi/v5/middleware/request_id.go:76 +0x20e\nnet/http.HandlerFunc.ServeHTTP(0x1?, {0x7f58fc8d18e0?, 0xc0004207c0?}, 0xc000420780?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngithub.com/go-chi/chi/v5.(*ChainHandler).ServeHTTP(0x1865820?, {0x7f58fc8d18e0?, 0xc0004207c0?}, 0xc0004ffa98?)\n\t/app/vendor/github.com/go-chi/chi/v5/chain.go:31 +0x26\ngithub.com/grafana/quickpizza/pkg/http.PrometheusMiddleware.func1({0x117f4d8, 0xc0001388c0}, 0xc0002cd9e0)\n\t/app/pkg/http/http.go:1048 +0xcc\nnet/http.HandlerFunc.ServeHTTP(0x1181258?, {0x117f4d8?, 0xc0001388c0?}, 0x1862d70?)\n\t/usr/local/go/src/net/http/server.go:2171 +0x29\ngithub.com/go-chi/chi/v5.(*Mux).ServeHTTP(0xc00011c0c0, {0x117f4d8, 0xc0001388c0}, 0xc0002cd8c0)\n\t/app/vendor/github.com/go-chi/chi/v5/mux.go:90 +0x2ee\ngithub.com/grafana/quickpizza/pkg/http.(*Server).ServeHTTP(0x470fb9?, {0x117f4d8?, 0xc0001388c0?}, 0xc0004ffb68?)\n\t/app/pkg/http/http.go:197 +0x29\nnet/http.serverHandler.ServeHTTP({0xc0003a3140?}, {0x117f4d8?, 0xc0001388c0?}, 0x6?)\n\t/usr/local/go/src/net/http/server.go:3142 +0x8e\nnet/http.(*conn).serve(0xc000255290, {0x1181220, 0xc00012b680})\n\t/usr/local/go/src/net/http/server.go:2044 +0x5e8\ncreated by net/http.(*Server).Serve in goroutine 1\n\t/usr/local/go/src/net/http/server.go:3290 +0x4b4\n","panic":"runtime error: invalid memory address or nil pointer dereference","httpResponse":{"status":500,"bytes":0,"elapsed":0.786835}}
```

This is caused because the Gateway Reverse Proxy does not have Routes deigned for the `/api/internal/recommendations` and `/api/admin/login` Endpoints, this PR adds them.

Its also adds a Debug log Entry for the Endpoint used for the Reverse Proxy to enable capturing this, if there are any other issues elsewhere.

EDIT: I added a few more missing endpoints, and added a default for the catalog, so _most_ endpoints should now work.