### PR TITLE
feat: Improve Faro Integration - Add Custom Events and Errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.19.1-bullseye AS fe-builder
+FROM node:23.10.0-bullseye AS fe-builder
 
 WORKDIR /app/pkg/web
 COPY pkg/web ./
@@ -12,7 +12,7 @@ ENV PUBLIC_BACKEND_WS_ENDPOINT=${PUBLIC_BACKEND_WS_ENDPOINT}
 RUN npm install && \
     npm run build
 
-FROM golang:1.22-bullseye AS builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /app
 COPY . ./

--- a/pkg/web/package-lock.json
+++ b/pkg/web/package-lock.json
@@ -12,8 +12,8 @@
 				"svelte-confetti": "^1.2.2"
 			},
 			"devDependencies": {
-				"@grafana/faro-web-sdk": "^1.10.0",
-				"@grafana/faro-web-tracing": "^1.10.0",
+				"@grafana/faro-web-sdk": "^1.14.1",
+				"@grafana/faro-web-tracing": "^1.14.1",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-static": "^2.0.1",
 				"@sveltejs/kit": "^1.5.0",
@@ -452,47 +452,55 @@
 			}
 		},
 		"node_modules/@grafana/faro-core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.10.0.tgz",
-			"integrity": "sha512-OxOdJQLnARRzS7cGvWuqdMuubuejoAcGrGX/gjWDxokC4CTIATTlnlCHdO+woPYAA+dqElCyQKbJ51jtrf3D6Q==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.14.1.tgz",
+			"integrity": "sha512-wPQEJ3Ow4s5m+scrHUHAbwCTMoXlXgwdjtO5PCKCimaI5q4nzFHp5D2FpFGDul2WfRVzwWvkhX6A7CGTui/myw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/otlp-transformer": "^0.53.0"
+				"@opentelemetry/otlp-transformer": "^0.57.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@grafana/faro-web-sdk": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.10.0.tgz",
-			"integrity": "sha512-4BqxaE/EaOijKfru8jjKztFRrLYcC2fC+RTAFZd6JSus0LlUpBGCAmfK7iEqsF8lY+Mzp5K9jJaG0ppMlK25eA==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.14.1.tgz",
+			"integrity": "sha512-Ii1xdpYysBfHO7XbK05uCXGwskDzLH7CYSdXU2gC8loRDR5PiqPzEczzVFeNhzGRcQzcecYWMxOzeucXdhNilw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grafana/faro-core": "^1.10.0",
+				"@grafana/faro-core": "^1.14.1",
 				"ua-parser-js": "^1.0.32",
 				"web-vitals": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@grafana/faro-web-tracing": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.10.0.tgz",
-			"integrity": "sha512-zbdEq0+2zyMaWSnBWITzhU+Yn/J0BxaYVYlOqKOTeOpTGv7+47PZ2lRiVwVVF0HWA+0WyA92SSzE2fKTK8y9Jg==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.14.1.tgz",
+			"integrity": "sha512-fbsWIj6XCyRD3wd7FAYvxtMMtsN5/I8wb6ak4JCp2iNt2aEa7lhLNTM6r5hKq6oSe77vrl/bfgI51qEw+mdoNw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grafana/faro-web-sdk": "^1.10.0",
+				"@grafana/faro-web-sdk": "^1.14.1",
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/context-zone": "1.26.0",
-				"@opentelemetry/core": "^1.26.0",
-				"@opentelemetry/exporter-trace-otlp-http": "^0.53.0",
-				"@opentelemetry/instrumentation": "^0.53.0",
-				"@opentelemetry/instrumentation-fetch": "^0.53.0",
-				"@opentelemetry/instrumentation-xml-http-request": "^0.53.0",
-				"@opentelemetry/otlp-transformer": "^0.53.0",
-				"@opentelemetry/resources": "^1.26.0",
-				"@opentelemetry/sdk-trace-web": "^1.26.0",
-				"@opentelemetry/semantic-conventions": "^1.27.0"
+				"@opentelemetry/core": "^1.30.0",
+				"@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+				"@opentelemetry/instrumentation": "^0.57.0",
+				"@opentelemetry/instrumentation-fetch": "^0.57.0",
+				"@opentelemetry/instrumentation-xml-http-request": "^0.57.0",
+				"@opentelemetry/otlp-transformer": "^0.57.1",
+				"@opentelemetry/resources": "^1.30.0",
+				"@opentelemetry/sdk-trace-web": "^1.30.0",
+				"@opentelemetry/semantic-conventions": "^1.28.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -599,54 +607,26 @@
 			}
 		},
 		"node_modules/@opentelemetry/api-logs": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-			"integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+			"integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/@opentelemetry/context-zone": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.26.0.tgz",
-			"integrity": "sha512-ckBEUKo7jZnZ2jARcntv365413cTe9Ra7uMQWvdk10K3tWOUsLnBG8dSMRbkaA+XL9hWGrZ1MMI8UXrwnbp0FA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/context-zone-peer-dep": "1.26.0",
-				"zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@opentelemetry/context-zone-peer-dep": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.26.0.tgz",
-			"integrity": "sha512-Mgdy0WsHR52h5AnN2nhZJrelDK6unOFr8aSn3ToETk6DLSOijayOi0M0SZM72qhWr7iFrJ1oxGEIK8uzVaSC8Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0",
-				"zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
-			"integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -655,34 +635,44 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
+		"node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-http": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
-			"integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.2.tgz",
+			"integrity": "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/otlp-exporter-base": "0.53.0",
-				"@opentelemetry/otlp-transformer": "0.53.0",
-				"@opentelemetry/resources": "1.26.0",
-				"@opentelemetry/sdk-trace-base": "1.26.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/otlp-exporter-base": "0.57.2",
+				"@opentelemetry/otlp-transformer": "0.57.2",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
-			"integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.53.0",
+				"@opentelemetry/api-logs": "0.57.2",
 				"@types/shimmer": "^1.2.0",
 				"import-in-the-middle": "^1.8.1",
 				"require-in-the-middle": "^7.1.1",
@@ -697,73 +687,93 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-fetch": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.53.0.tgz",
-			"integrity": "sha512-Sayp/Oypr0lyTgOKide/Dz4ovqDWPdmazapCMyfsVpXpV9zrH2kbdO2vAKUMx9vF98vxsqcxXucf4z54WXWZ8A==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.57.2.tgz",
+			"integrity": "sha512-LF/lH9xpRTuGPdxta6Eiezw91DFm0A9SMux1vslNwSgL4jiB+q1fQ/8CRv7e5UNh7y/hit4LAdGPoH+f0wfTTQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/instrumentation": "0.53.0",
-				"@opentelemetry/sdk-trace-web": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/instrumentation": "0.57.2",
+				"@opentelemetry/sdk-trace-web": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-fetch/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-xml-http-request": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.53.0.tgz",
-			"integrity": "sha512-vkALs8zdEUU3GnGvq1rzP0RK3+Fsk2jyzY6X/a+ibbo/miCmmeQNHX+fBRNs/3Offquj19M0qD+olNU9CJloqg==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.57.2.tgz",
+			"integrity": "sha512-9niBJT2egcytOqDEfA27xc6TIqlOTEzQYNli2lWuw+K7TeO7KcyYzmIeS/S6BYLulOsOWtvlE6CDDxXg+GUepw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/instrumentation": "0.53.0",
-				"@opentelemetry/sdk-trace-web": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/instrumentation": "0.57.2",
+				"@opentelemetry/sdk-trace-web": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-xml-http-request/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
-			"integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+			"integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/otlp-transformer": "0.53.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/otlp-transformer": "0.57.2"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
-			"integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+			"integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.53.0",
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0",
-				"@opentelemetry/sdk-logs": "0.53.0",
-				"@opentelemetry/sdk-metrics": "1.26.0",
-				"@opentelemetry/sdk-trace-base": "1.26.0",
+				"@opentelemetry/api-logs": "0.57.2",
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/sdk-logs": "0.57.2",
+				"@opentelemetry/sdk-metrics": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1",
 				"protobufjs": "^7.3.0"
 			},
 			"engines": {
@@ -774,14 +784,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
-			"integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -790,16 +800,26 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
+		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
-			"integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+			"integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.53.0",
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0"
+				"@opentelemetry/api-logs": "0.57.2",
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1"
 			},
 			"engines": {
 				"node": ">=14"
@@ -809,14 +829,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
-			"integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+			"integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1"
 			},
 			"engines": {
 				"node": ">=14"
@@ -826,33 +846,43 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
-			"integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-web": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.26.0.tgz",
-			"integrity": "sha512-sxeKPcG/gUyxZ8iB8X1MI8/grfSCGgo1n2kxOE73zjVaO9yW/7JuVC3gqUaWRjtZ6VD/V3lo2/ZSwMlm6n2mdg==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.30.1.tgz",
+			"integrity": "sha512-AUo2e+1uyTGMB36VlbvBqnCogVzQhpC7dRcVVdCrt+cFHLpFRRJcd45J2obGTgs0XiAwNLyq5bhkW3JF2NZA+A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/sdk-trace-base": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -861,10 +891,20 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
+		"node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-			"integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+			"integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1274,10 +1314,11 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1607,9 +1648,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-			"integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2408,13 +2449,13 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz",
-			"integrity": "sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+			"integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"acorn": "^8.8.2",
+				"acorn": "^8.14.0",
 				"acorn-import-attributes": "^1.9.5",
 				"cjs-module-lexer": "^1.2.2",
 				"module-details-from-path": "^1.0.3"
@@ -2615,9 +2656,9 @@
 			"dev": true
 		},
 		"node_modules/long": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+			"integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -3196,9 +3237,9 @@
 			}
 		},
 		"node_modules/require-in-the-middle": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz",
-			"integrity": "sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==",
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4035,13 +4076,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/zone.js": {
-			"version": "0.14.10",
-			"resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
-			"integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
-			"dev": true,
-			"license": "MIT"
 		}
 	},
 	"dependencies": {
@@ -4244,44 +4278,43 @@
 			"dev": true
 		},
 		"@grafana/faro-core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.10.0.tgz",
-			"integrity": "sha512-OxOdJQLnARRzS7cGvWuqdMuubuejoAcGrGX/gjWDxokC4CTIATTlnlCHdO+woPYAA+dqElCyQKbJ51jtrf3D6Q==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.14.1.tgz",
+			"integrity": "sha512-wPQEJ3Ow4s5m+scrHUHAbwCTMoXlXgwdjtO5PCKCimaI5q4nzFHp5D2FpFGDul2WfRVzwWvkhX6A7CGTui/myw==",
 			"dev": true,
 			"requires": {
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/otlp-transformer": "^0.53.0"
+				"@opentelemetry/otlp-transformer": "^0.57.1"
 			}
 		},
 		"@grafana/faro-web-sdk": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.10.0.tgz",
-			"integrity": "sha512-4BqxaE/EaOijKfru8jjKztFRrLYcC2fC+RTAFZd6JSus0LlUpBGCAmfK7iEqsF8lY+Mzp5K9jJaG0ppMlK25eA==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.14.1.tgz",
+			"integrity": "sha512-Ii1xdpYysBfHO7XbK05uCXGwskDzLH7CYSdXU2gC8loRDR5PiqPzEczzVFeNhzGRcQzcecYWMxOzeucXdhNilw==",
 			"dev": true,
 			"requires": {
-				"@grafana/faro-core": "^1.10.0",
+				"@grafana/faro-core": "^1.14.1",
 				"ua-parser-js": "^1.0.32",
 				"web-vitals": "^4.0.1"
 			}
 		},
 		"@grafana/faro-web-tracing": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.10.0.tgz",
-			"integrity": "sha512-zbdEq0+2zyMaWSnBWITzhU+Yn/J0BxaYVYlOqKOTeOpTGv7+47PZ2lRiVwVVF0HWA+0WyA92SSzE2fKTK8y9Jg==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.14.1.tgz",
+			"integrity": "sha512-fbsWIj6XCyRD3wd7FAYvxtMMtsN5/I8wb6ak4JCp2iNt2aEa7lhLNTM6r5hKq6oSe77vrl/bfgI51qEw+mdoNw==",
 			"dev": true,
 			"requires": {
-				"@grafana/faro-web-sdk": "^1.10.0",
+				"@grafana/faro-web-sdk": "^1.14.1",
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/context-zone": "1.26.0",
-				"@opentelemetry/core": "^1.26.0",
-				"@opentelemetry/exporter-trace-otlp-http": "^0.53.0",
-				"@opentelemetry/instrumentation": "^0.53.0",
-				"@opentelemetry/instrumentation-fetch": "^0.53.0",
-				"@opentelemetry/instrumentation-xml-http-request": "^0.53.0",
-				"@opentelemetry/otlp-transformer": "^0.53.0",
-				"@opentelemetry/resources": "^1.26.0",
-				"@opentelemetry/sdk-trace-web": "^1.26.0",
-				"@opentelemetry/semantic-conventions": "^1.27.0"
+				"@opentelemetry/core": "^1.30.0",
+				"@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+				"@opentelemetry/instrumentation": "^0.57.0",
+				"@opentelemetry/instrumentation-fetch": "^0.57.0",
+				"@opentelemetry/instrumentation-xml-http-request": "^0.57.0",
+				"@opentelemetry/otlp-transformer": "^0.57.1",
+				"@opentelemetry/resources": "^1.30.0",
+				"@opentelemetry/sdk-trace-web": "^1.30.0",
+				"@opentelemetry/semantic-conventions": "^1.28.0"
 			}
 		},
 		"@humanwhocodes/config-array": {
@@ -4362,60 +4395,51 @@
 			"dev": true
 		},
 		"@opentelemetry/api-logs": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-			"integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+			"integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
 			}
-		},
-		"@opentelemetry/context-zone": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.26.0.tgz",
-			"integrity": "sha512-ckBEUKo7jZnZ2jARcntv365413cTe9Ra7uMQWvdk10K3tWOUsLnBG8dSMRbkaA+XL9hWGrZ1MMI8UXrwnbp0FA==",
-			"dev": true,
-			"requires": {
-				"@opentelemetry/context-zone-peer-dep": "1.26.0",
-				"zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
-			}
-		},
-		"@opentelemetry/context-zone-peer-dep": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.26.0.tgz",
-			"integrity": "sha512-Mgdy0WsHR52h5AnN2nhZJrelDK6unOFr8aSn3ToETk6DLSOijayOi0M0SZM72qhWr7iFrJ1oxGEIK8uzVaSC8Q==",
-			"dev": true,
-			"requires": {}
 		},
 		"@opentelemetry/core": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
-			"integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.28.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+					"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+					"dev": true
+				}
 			}
 		},
 		"@opentelemetry/exporter-trace-otlp-http": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
-			"integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.2.tgz",
+			"integrity": "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/otlp-exporter-base": "0.53.0",
-				"@opentelemetry/otlp-transformer": "0.53.0",
-				"@opentelemetry/resources": "1.26.0",
-				"@opentelemetry/sdk-trace-base": "1.26.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/otlp-exporter-base": "0.57.2",
+				"@opentelemetry/otlp-transformer": "0.57.2",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1"
 			}
 		},
 		"@opentelemetry/instrumentation": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
-			"integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-logs": "0.53.0",
+				"@opentelemetry/api-logs": "0.57.2",
 				"@types/shimmer": "^1.2.0",
 				"import-in-the-middle": "^1.8.1",
 				"require-in-the-middle": "^7.1.1",
@@ -4424,111 +4448,151 @@
 			}
 		},
 		"@opentelemetry/instrumentation-fetch": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.53.0.tgz",
-			"integrity": "sha512-Sayp/Oypr0lyTgOKide/Dz4ovqDWPdmazapCMyfsVpXpV9zrH2kbdO2vAKUMx9vF98vxsqcxXucf4z54WXWZ8A==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.57.2.tgz",
+			"integrity": "sha512-LF/lH9xpRTuGPdxta6Eiezw91DFm0A9SMux1vslNwSgL4jiB+q1fQ/8CRv7e5UNh7y/hit4LAdGPoH+f0wfTTQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/instrumentation": "0.53.0",
-				"@opentelemetry/sdk-trace-web": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/instrumentation": "0.57.2",
+				"@opentelemetry/sdk-trace-web": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.28.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+					"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+					"dev": true
+				}
 			}
 		},
 		"@opentelemetry/instrumentation-xml-http-request": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.53.0.tgz",
-			"integrity": "sha512-vkALs8zdEUU3GnGvq1rzP0RK3+Fsk2jyzY6X/a+ibbo/miCmmeQNHX+fBRNs/3Offquj19M0qD+olNU9CJloqg==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.57.2.tgz",
+			"integrity": "sha512-9niBJT2egcytOqDEfA27xc6TIqlOTEzQYNli2lWuw+K7TeO7KcyYzmIeS/S6BYLulOsOWtvlE6CDDxXg+GUepw==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/instrumentation": "0.53.0",
-				"@opentelemetry/sdk-trace-web": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/instrumentation": "0.57.2",
+				"@opentelemetry/sdk-trace-web": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.28.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+					"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+					"dev": true
+				}
 			}
 		},
 		"@opentelemetry/otlp-exporter-base": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
-			"integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+			"integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/otlp-transformer": "0.53.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/otlp-transformer": "0.57.2"
 			}
 		},
 		"@opentelemetry/otlp-transformer": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
-			"integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+			"integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-logs": "0.53.0",
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0",
-				"@opentelemetry/sdk-logs": "0.53.0",
-				"@opentelemetry/sdk-metrics": "1.26.0",
-				"@opentelemetry/sdk-trace-base": "1.26.0",
+				"@opentelemetry/api-logs": "0.57.2",
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/sdk-logs": "0.57.2",
+				"@opentelemetry/sdk-metrics": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1",
 				"protobufjs": "^7.3.0"
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
-			"integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.28.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+					"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+					"dev": true
+				}
 			}
 		},
 		"@opentelemetry/sdk-logs": {
-			"version": "0.53.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
-			"integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+			"integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-logs": "0.53.0",
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0"
+				"@opentelemetry/api-logs": "0.57.2",
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1"
 			}
 		},
 		"@opentelemetry/sdk-metrics": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
-			"integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+			"integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1"
 			}
 		},
 		"@opentelemetry/sdk-trace-base": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
-			"integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/resources": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.28.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+					"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+					"dev": true
+				}
 			}
 		},
 		"@opentelemetry/sdk-trace-web": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.26.0.tgz",
-			"integrity": "sha512-sxeKPcG/gUyxZ8iB8X1MI8/grfSCGgo1n2kxOE73zjVaO9yW/7JuVC3gqUaWRjtZ6VD/V3lo2/ZSwMlm6n2mdg==",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.30.1.tgz",
+			"integrity": "sha512-AUo2e+1uyTGMB36VlbvBqnCogVzQhpC7dRcVVdCrt+cFHLpFRRJcd45J2obGTgs0XiAwNLyq5bhkW3JF2NZA+A==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "1.26.0",
-				"@opentelemetry/sdk-trace-base": "1.26.0",
-				"@opentelemetry/semantic-conventions": "1.27.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.28.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+					"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+					"dev": true
+				}
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-			"integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+			"integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
 			"dev": true
 		},
 		"@polka/url": {
@@ -4803,9 +4867,9 @@
 			}
 		},
 		"acorn": {
-			"version": "8.8.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
 			"dev": true
 		},
 		"acorn-import-attributes": {
@@ -5021,9 +5085,9 @@
 			}
 		},
 		"cjs-module-lexer": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-			"integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
 			"dev": true
 		},
 		"color-convert": {
@@ -5626,12 +5690,12 @@
 			}
 		},
 		"import-in-the-middle": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz",
-			"integrity": "sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+			"integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^8.8.2",
+				"acorn": "^8.14.0",
 				"acorn-import-attributes": "^1.9.5",
 				"cjs-module-lexer": "^1.2.2",
 				"module-details-from-path": "^1.0.3"
@@ -5781,9 +5845,9 @@
 			"dev": true
 		},
 		"long": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+			"integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
 			"dev": true
 		},
 		"magic-string": {
@@ -6160,9 +6224,9 @@
 			"dev": true
 		},
 		"require-in-the-middle": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz",
-			"integrity": "sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==",
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.3.5",
@@ -6664,12 +6728,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true
-		},
-		"zone.js": {
-			"version": "0.14.10",
-			"resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
-			"integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
 			"dev": true
 		}
 	}

--- a/pkg/web/package.json
+++ b/pkg/web/package.json
@@ -12,8 +12,8 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
-		"@grafana/faro-web-sdk": "^1.10.0",
-		"@grafana/faro-web-tracing": "^1.10.0",
+		"@grafana/faro-web-sdk": "^1.14.1",
+		"@grafana/faro-web-tracing": "^1.14.1",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-static": "^2.0.1",
 		"@sveltejs/kit": "^1.5.0",

--- a/pkg/web/src/routes/+page.svelte
+++ b/pkg/web/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { faro } from '@grafana/faro-web-sdk';
 	import { PUBLIC_BACKEND_ENDPOINT, PUBLIC_BACKEND_WS_ENDPOINT } from '$env/static/public';
 	import { onMount } from 'svelte';
 	import { Confetti } from 'svelte-confetti';
@@ -95,9 +96,11 @@
 		});
 		getTools();
 		render = true;
+		faro.api.pushEvent('Navigation', { url: window.location.href });
 	});
 
 	async function ratePizza(stars) {
+		faro.api.pushEvent('Submit Pizza Rating', {pizza_id: pizza['pizza']['id'], stars: stars});
 		const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/ratings`, {
 			method: 'POST',
 			body: JSON.stringify({
@@ -109,10 +112,15 @@
 			rateResult = 'Rated!';
 		} else {
 			rateResult = 'Please log in first.';
+			faro.api.pushError(new Error('Unauthenticated Ratings Submission'));
 		}
 	}
 
 	async function getPizza() {
+		faro.api.pushEvent('Get Pizza Recommendation', {restrictions: restrictions});
+		if (restrictions.minNumberOfToppings > restrictions.maxNumberOfToppings) {
+			faro.api.pushError(new Error('Invalid Restrictions, Min > Max'));
+		}
 		const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/pizza`, {
 			method: 'POST',
 			body: JSON.stringify(restrictions),
@@ -135,9 +143,13 @@
 				})
 			);
 		}
+		if (pizza['pizza']['ingredients'].find(e => e.name === 'Pineapple')) {
+			faro.api.pushError(new Error('Bad Pizza Recommendation'));
+		}
 	}
 
 	async function getTools() {
+		faro.api.pushEvent('Get Pizza Tools', {tools: tools});
 		const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/tools`, {
 			headers: {
 				Authorization: 'Token ' + userToken

--- a/pkg/web/src/routes/login/+page.svelte
+++ b/pkg/web/src/routes/login/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { faro } from '@grafana/faro-web-sdk';
 	import { PUBLIC_BACKEND_ENDPOINT } from '$env/static/public';
 	import { onMount } from 'svelte';
 
@@ -52,9 +53,12 @@
 		});
 		if (!res.ok) {
 			loginError = 'Login failed: ' + res.statusText;
+			faro.api.pushEvent('Unsuccessful Login', {username: username});
+			faro.api.pushError(new Error('Login Error: ' + res.statusText));
 			return;
 		}
 
+		faro.api.pushEvent('Successful Login', {username: username});
 		qpUserLoggedIn = checkQPUserLoggedIn();
 	}
 
@@ -92,6 +96,7 @@
 	}
 
 	async function handleLogout() {
+		faro.api.pushEvent('User Logout');
 		document.cookie = 'qp_user_token=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
 		qpUserLoggedIn = false;
 	}


### PR DESCRIPTION
This adds some custom Faro Events and Errors to certain UI actions, to help further showcase Frontend Observability.

It also bumps the Faro Dependency versions, which due to other dependencies, requires a bump of the Node and Go versions.