### PR TITLE
Fix Prettier Lint Issues and Issues with Faro Initialization

### DIFF
--- a/pkg/web/src/hooks.client.ts
+++ b/pkg/web/src/hooks.client.ts
@@ -6,13 +6,14 @@ function setupFaro() {
 	fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/config`)
 		.then((data) => data.json())
 		.then((config) => {
-			const url = config.faro_url;
+			let url = config.faro_url;
 			if (!url) {
-				console.warn('Grafana faro is not configured.');
-				return;
+				console.warn('Grafana Faro is not configured.');
+				url = `${PUBLIC_BACKEND_ENDPOINT}/faro`
+			} else {
+				console.log(`Initializing Grafana Faro to '${url}'`);
 			}
 
-			console.log(`Initializing Grafana Faro to ${url}`);
 			initializeFaro({
 				url,
 				app: {

--- a/pkg/web/src/hooks.client.ts
+++ b/pkg/web/src/hooks.client.ts
@@ -6,10 +6,9 @@ function setupFaro() {
 	fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/config`)
 		.then((data) => data.json())
 		.then((config) => {
-			let url = config.faro_url;
+			const url = config.faro_url;
 			if (!url) {
 				console.warn('Grafana Faro is not configured.');
-				url = `${PUBLIC_BACKEND_ENDPOINT}/faro`;
 			}
 
 			console.log(`Initializing Grafana Faro to '${url}'`);

--- a/pkg/web/src/hooks.client.ts
+++ b/pkg/web/src/hooks.client.ts
@@ -10,10 +10,9 @@ function setupFaro() {
 			if (!url) {
 				console.warn('Grafana Faro is not configured.');
 				url = `${PUBLIC_BACKEND_ENDPOINT}/faro`;
-			} else {
-				console.log(`Initializing Grafana Faro to '${url}'`);
 			}
 
+			console.log(`Initializing Grafana Faro to '${url}'`);
 			initializeFaro({
 				url,
 				app: {

--- a/pkg/web/src/hooks.client.ts
+++ b/pkg/web/src/hooks.client.ts
@@ -9,7 +9,7 @@ function setupFaro() {
 			let url = config.faro_url;
 			if (!url) {
 				console.warn('Grafana Faro is not configured.');
-				url = `${PUBLIC_BACKEND_ENDPOINT}/faro`
+				url = `${PUBLIC_BACKEND_ENDPOINT}/faro`;
 			} else {
 				console.log(`Initializing Grafana Faro to '${url}'`);
 			}

--- a/pkg/web/src/routes/+page.svelte
+++ b/pkg/web/src/routes/+page.svelte
@@ -100,7 +100,7 @@
 	});
 
 	async function ratePizza(stars) {
-		faro.api.pushEvent('Submit Pizza Rating', {pizza_id: pizza['pizza']['id'], stars: stars});
+		faro.api.pushEvent('Submit Pizza Rating', { pizza_id: pizza['pizza']['id'], stars: stars });
 		const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/ratings`, {
 			method: 'POST',
 			body: JSON.stringify({
@@ -120,7 +120,7 @@
 	}
 
 	async function getPizza() {
-		faro.api.pushEvent('Get Pizza Recommendation', {restrictions: restrictions});
+		faro.api.pushEvent('Get Pizza Recommendation', { restrictions: restrictions });
 		if (restrictions.minNumberOfToppings > restrictions.maxNumberOfToppings) {
 			faro.api.pushError(new Error('Invalid Restrictions, Min > Max'));
 		}
@@ -147,13 +147,13 @@
 				})
 			);
 		}
-		if (pizza['pizza']['ingredients'].find(e => e.name === 'Pineapple')) {
+		if (pizza['pizza']['ingredients'].find((e) => e.name === 'Pineapple')) {
 			faro.api.pushError(new Error('Bad Pizza Recommendation'));
 		}
 	}
 
 	async function getTools() {
-		faro.api.pushEvent('Get Pizza Tools', {tools: tools});
+		faro.api.pushEvent('Get Pizza Tools', { tools: tools });
 		const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/tools`, {
 			headers: {
 				Authorization: 'Token ' + userToken

--- a/pkg/web/src/routes/admin/+page.svelte
+++ b/pkg/web/src/routes/admin/+page.svelte
@@ -32,12 +32,12 @@
 		);
 		if (!res.ok) {
 			loginError = 'Login failed: ' + res.statusText;
-			faro.api.pushEvent('Unsuccessful Admin Login', {username: username});
+			faro.api.pushEvent('Unsuccessful Admin Login', { username: username });
 			faro.api.pushError(new Error('Admin Login Error: ' + res.statusText));
 			return;
 		}
 
-		faro.api.pushEvent('Successful Admin Login', {username: username});
+		faro.api.pushEvent('Successful Admin Login', { username: username });
 		adminLoggedIn = checkAdminLoggedIn();
 	}
 
@@ -59,7 +59,7 @@
 		})
 			.then((res) => res.json())
 			.then((json) => {
-				faro.api.pushEvent('Update Recent Pizza Recommendations',);
+				faro.api.pushEvent('Update Recent Pizza Recommendations');
 				var newRec: string[] = [];
 				json.pizzas.forEach((pizza: string) => {
 					newRec.push(`

--- a/pkg/web/src/routes/login/+page.svelte
+++ b/pkg/web/src/routes/login/+page.svelte
@@ -56,12 +56,12 @@
 		});
 		if (!res.ok) {
 			loginError = 'Login failed: ' + res.statusText;
-			faro.api.pushEvent('Unsuccessful Login', {username: username});
+			faro.api.pushEvent('Unsuccessful Login', { username: username });
 			faro.api.pushError(new Error('Login Error: ' + res.statusText));
 			return;
 		}
 
-		faro.api.pushEvent('Successful Login', {username: username});
+		faro.api.pushEvent('Successful Login', { username: username });
 		qpUserLoggedIn = checkQPUserLoggedIn();
 	}
 


### PR DESCRIPTION
This PR fixes two issues form previous PRs that are merged;

---

This fixes a couple of minor issues reported by `prettier` in the CI build.

See: https://github.com/grafana/quickpizza/actions/runs/15067140875/job/42354426438

---

It also fixes another issue found in testing here (and caused by #205), where if Faro is not initialized, the page fails to show any recommendations, or allows pages to be used, because its calling something that is undefined. Its a bit of an edge case as if the App is Instrumented with Faro, it expects a URL to be given, but here its an optional value.

So, to workaround this, if no Faro URL is provided, we still initialize Faro, but it does not have a URL defines, allowing the `faro` object to be accessible and used, without causing issues.