### PR TITLE
add logs support to cloud

### DIFF
--- a/kubernetes/grafana-alloy/base/resources/deployment.yaml
+++ b/kubernetes/grafana-alloy/base/resources/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.k8s.io/name: grafana-alloy
     spec:
       restartPolicy: Always
-      serviceAccountName: grafana-alloy
+      serviceAccountName: grafana-alloy-sa
       containers:
         - name: grafana-alloy
           image: grafana/alloy:v1.9.1

--- a/kubernetes/grafana-alloy/base/resources/rbac.yaml
+++ b/kubernetes/grafana-alloy/base/resources/rbac.yaml
@@ -2,16 +2,17 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: grafana-alloy
+  name: grafana-alloy-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: grafana-alloy
+  name: grafana-alloy-crb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: view
 subjects:
 - kind: ServiceAccount
-  name: grafana-alloy
+  name: grafana-alloy-sa
+

--- a/kubernetes/grafana-alloy/cloud/config/grafana-alloy.river
+++ b/kubernetes/grafana-alloy/cloud/config/grafana-alloy.river
@@ -1,3 +1,59 @@
+// Discovery
+discovery.kubernetes "application_pods" {
+  selectors {
+    label = "app.k8s.io/name=quickpizza"
+    role = "pod"
+  }
+  role = "pod"
+  namespaces {
+    own_namespace = true
+  }
+}
+
+discovery.relabel "relabel_targets" {
+  rule {
+    target_label = "job"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+    ]
+  }
+  rule {
+    target_label = "service_name"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+    ]
+  }
+  rule {
+    target_label = "instance"
+    source_labels = [
+      "__meta_kubernetes_pod_name",
+    ]
+  }
+  targets = discovery.kubernetes.application_pods.targets
+}
+
+// Metrics
+prometheus.scrape "default" {
+  forward_to = [
+    grafana_cloud.stack.receivers.metrics,
+  ]
+  targets = discovery.relabel.relabel_targets.output
+}
+
+// Logs
+loki.source.kubernetes "pods" {
+  targets    = discovery.kubernetes.application_pods.targets
+  forward_to = [
+    grafana_cloud.stack.receivers.logs,
+  ]
+}
+
+loki.source.kubernetes_events "k8s_event_logs" {
+  forward_to = [
+    grafana_cloud.stack.receivers.logs,
+  ]
+}
+
 // Traces
 otelcol.receiver.otlp "default" {
   grpc {
@@ -23,46 +79,7 @@ otelcol.processor.batch "default" {
   }
 }
 
-// Metrics
-discovery.kubernetes "application_pods" {
-  selectors {
-    label = "app.k8s.io/name=quickpizza"
-    role = "pod"
-  }
-  role = "pod"
-  namespaces {
-    own_namespace = true
-  }
-}
-prometheus.scrape "default" {
-  forward_to = [
-    grafana_cloud.stack.receivers.metrics,
-  ]
-  targets = discovery.relabel.relabel_targets.output
-}
-
-discovery.relabel "relabel_targets" {
-  rule {
-    target_label = "job"
-    source_labels = [
-      "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
-    ]
-  }
-  rule {
-    target_label = "service_name"
-    source_labels = [
-      "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
-    ]
-  }
-  rule {
-    target_label = "instance"
-    source_labels = [
-      "__meta_kubernetes_pod_name",
-    ]
-  }
-  targets = discovery.kubernetes.application_pods.targets
-}
-
+// Profiles
 pyroscope.scrape "scrape_profiles" {
   forward_to = [
     grafana_cloud.stack.receivers.profiles,


### PR DESCRIPTION
This adds support for sending pod logs and Kubernetes events to Grafana Cloud Logs.

I also:

- changed the `ServiceAccount` name to `grafana-alloy-sa` to distinguish its name from other places we use `grafana-alloy`
- reorganized `grafana-alloy.river` slightly