### PR TITLE
Browser: Use external API

### DIFF
--- a/pkg/web/test.k6.io/browser.html
+++ b/pkg/web/test.k6.io/browser.html
@@ -91,6 +91,19 @@
 				}
 				sDisplay.textContent = opts;
 			}
+
+			function fetchExternalData() {
+				const dataDisplay = document.getElementById('external-data-display');
+				fetch('https://jsonplaceholder.typicode.com/todos/1')
+					.then((response) => response.json())
+					.then((data) => {
+						dataDisplay.textContent = 'External data: ' + data.title;
+					})
+					.catch((error) => {
+						console.error('Error:', error);
+						alert('API call failed. Check console for error.');
+					});
+			}
 		</script>
 	</head>
 
@@ -205,6 +218,12 @@
 						<option value="black">Black</option>
 						<option value="white">White</option>
 					</select>
+				</td>
+			</tr>
+			<tr>
+				<td><button type="button" onclick="fetchExternalData()">Fetch external data</button></td>
+				<td>
+					<p id="external-data-display">External data: ?</p>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
This adds a call to an external API in `/browser.php`.

This allows to test features that we are currently implementing in `k6/browser` like `page.route` function and adds some CORS to test for more complex use cases. 
