### PR TITLE
Support running distinct Alloy configs in Docker Compose Cloud setup

### DIFF
--- a/alloy/cloud-otel.alloy
+++ b/alloy/cloud-otel.alloy
@@ -1,0 +1,210 @@
+
+// Enable this config by setting the env var ALLOY_FILE_NAME to cloud-otel.alloy for the docker-compose-cloud.yaml
+
+import.git "grafana_cloud" {
+  repository = "https://github.com/grafana/alloy-modules.git"
+  revision = "main"
+  path = "modules/cloud/grafana/cloud/module.alloy"
+  pull_frequency = "24h"
+}
+grafana_cloud.stack "receivers" {
+  stack_name = env("GRAFANA_CLOUD_STACK")
+  token = env("GRAFANA_CLOUD_TOKEN")
+}
+
+otelcol.auth.basic "grafana_cloud" {
+  username = grafana_cloud.stack.receivers.info["htInstanceId"]
+  password = env("GRAFANA_CLOUD_TOKEN")
+}
+
+otelcol.exporter.otlphttp "grafana_cloud" {
+  client {
+    endpoint = grafana_cloud.stack.receivers.info["htInstanceUrl"] + ":443"
+    auth     = otelcol.auth.basic.grafana_cloud.handler
+  }
+}
+
+
+discovery.docker "all_containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "relabel_targets" {
+  rule {
+    target_label = "instance"
+    source_labels = [
+      "__meta_docker_container_name",
+    ]
+    regex ="/(.*)"
+    action = "replace"
+  }
+  rule {
+    target_label = "job"
+    source_labels = [
+      "__meta_docker_container_label_com_docker_compose_project",
+    ]
+    regex = ".*quickpizza.*"
+    action = "keep"
+  }
+  targets = discovery.docker.all_containers.targets
+}
+
+
+// Metrics
+prometheus.scrape "default" {
+  forward_to = [grafana_cloud.stack.receivers.metrics]
+  targets = discovery.relabel.relabel_targets.output
+}
+
+loki.source.docker "default" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.relabel_targets.output
+  forward_to = [grafana_cloud.stack.receivers.logs]
+  labels = {
+    service_name = "quickpizza",
+    service_namespace = "quickpizza",
+  }
+}
+
+pyroscope.scrape "scrape_profiles" {
+  forward_to = [grafana_cloud.stack.receivers.profiles]
+  targets = discovery.relabel.relabel_targets.output
+}
+
+pyroscope.receive_http "default" {
+   forward_to = [grafana_cloud.stack.receivers.profiles]
+   http {
+       listen_address = "0.0.0.0"
+       listen_port = 9999
+   }
+}
+
+
+otelcol.receiver.otlp "default" {
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.receiver.otlp/
+    
+  // configures the default grpc endpoint "0.0.0.0:4317"
+  grpc { }
+  // configures the default http/protobuf endpoint "0.0.0.0:4318"
+  http { }
+    
+  output {
+    metrics = [otelcol.processor.resourcedetection.default.input]
+    logs    = [otelcol.processor.resourcedetection.default.input]
+    traces  = [otelcol.processor.resourcedetection.default.input]
+  }
+}
+    
+otelcol.processor.resourcedetection "default" {
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.resourcedetection/
+  detectors = ["env", "system"] // add "gcp", "ec2", "ecs", "elastic_beanstalk", "eks", "lambda", "azure", "aks", "consul", "heroku"  if you want to use cloud resource detection
+    
+  system {
+    hostname_sources = ["os"]
+  }
+    
+  output {
+    metrics = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
+    logs    = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
+    traces  = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
+  }
+}
+    
+otelcol.processor.transform "drop_unneeded_resource_attributes" {
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/
+  error_mode = "ignore"
+    
+  trace_statements {
+    context    = "resource"
+    statements = [
+    	"delete_key(attributes, \"k8s.pod.start_time\")",
+    	"delete_key(attributes, \"os.description\")",
+    	"delete_key(attributes, \"os.type\")",
+    	"delete_key(attributes, \"process.command_args\")",
+    	"delete_key(attributes, \"process.executable.path\")",
+    	"delete_key(attributes, \"process.pid\")",
+    	"delete_key(attributes, \"process.runtime.description\")",
+    	"delete_key(attributes, \"process.runtime.name\")",
+    	"delete_key(attributes, \"process.runtime.version\")",
+    ]
+  }
+    
+  metric_statements {
+    context    = "resource"
+    statements = [
+    	"delete_key(attributes, \"k8s.pod.start_time\")",
+    	"delete_key(attributes, \"os.description\")",
+    	"delete_key(attributes, \"os.type\")",
+    	"delete_key(attributes, \"process.command_args\")",
+    	"delete_key(attributes, \"process.executable.path\")",
+    	"delete_key(attributes, \"process.pid\")",
+    	"delete_key(attributes, \"process.runtime.description\")",
+    	"delete_key(attributes, \"process.runtime.name\")",
+    	"delete_key(attributes, \"process.runtime.version\")",
+    ]
+  }
+    
+  log_statements {
+    context    = "resource"
+    statements = [
+    	"delete_key(attributes, \"k8s.pod.start_time\")",
+    	"delete_key(attributes, \"os.description\")",
+    	"delete_key(attributes, \"os.type\")",
+    	"delete_key(attributes, \"process.command_args\")",
+    	"delete_key(attributes, \"process.executable.path\")",
+    	"delete_key(attributes, \"process.pid\")",
+    	"delete_key(attributes, \"process.runtime.description\")",
+    	"delete_key(attributes, \"process.runtime.name\")",
+    	"delete_key(attributes, \"process.runtime.version\")",
+    ]
+  }
+    
+  output {
+    metrics = [otelcol.processor.transform.add_resource_attributes_as_metric_attributes.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [
+    	otelcol.processor.batch.default.input,
+    	otelcol.connector.host_info.default.input,
+    ]
+  }
+}
+    
+otelcol.connector.host_info "default" {
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.connector.host_info/
+  host_identifiers = ["container.name", "container.id", "service.name"]
+  metrics_flush_interval = "10s"
+    
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+  }
+}
+    
+otelcol.processor.transform "add_resource_attributes_as_metric_attributes" {
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/
+  error_mode = "ignore"
+    
+  metric_statements {
+    context    = "datapoint"
+    statements = [
+    	"set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
+    	"set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+    
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  // https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.batch/
+  output {
+    metrics = [otelcol.exporter.otlphttp.grafana_cloud.input]
+    logs    = [otelcol.exporter.otlphttp.grafana_cloud.input]
+    // traces  = [otelcol.exporter.otlphttp.grafana_cloud.input]
+    
+    //metrics = [grafana_cloud.stack.receivers.metrics]
+    //logs    = [grafana_cloud.stack.receivers.logs]
+    traces  = [grafana_cloud.stack.receivers.traces]
+  }
+}

--- a/docker-compose-cloud.yaml
+++ b/docker-compose-cloud.yaml
@@ -25,7 +25,7 @@ services:
   alloy:
     image: grafana/alloy:v1.9.1
     volumes:
-      - "./alloy/cloud.alloy:/config.alloy:Z"
+      - "./alloy/${ALLOY_FILE_NAME:-cloud.alloy}:/config.alloy:Z"
       - "${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock"
     command:
       - run


### PR DESCRIPTION
This PR adds support for running multiple Alloy configurations in the docker-compose-cloud.yaml setup. You can now specify the configuration file using the ALLOY_FILE_NAME environment variable.

This PR does not introduce breaking changes.
