### PR TITLE
fix: Panic with Router when Registering Routes for Profiling Pull Mode

### DIFF
--- a/.github/workflows/example_basic_test.yaml
+++ b/.github/workflows/example_basic_test.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_browser_test.yaml
+++ b/.github/workflows/example_browser_test.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_cli_flags_test.yaml
+++ b/.github/workflows/example_cli_flags_test.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_env_var.yaml
+++ b/.github/workflows/example_env_var.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3355:3333
 

--- a/.github/workflows/example_specific_k6_version.yaml
+++ b/.github/workflows/example_specific_k6_version.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_verify_scripts.yaml
+++ b/.github/workflows/example_verify_scripts.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/k6_browser_tests.yaml
+++ b/.github/workflows/k6_browser_tests.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/k6_tests.yaml
+++ b/.github/workflows/k6_tests.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:latest
+        image: ghcr.io/grafana/quickpizza-local:latest # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -15,7 +15,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
-
 	_ "net/http/pprof"
 	"net/url"
 	"os"

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 
-	// _ "net/http/pprof"
+	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"slices"
@@ -261,11 +261,11 @@ func NewServer(profiling bool, traceInstaller *TraceInstaller) *Server {
 		}).Handler,
 	)
 
-	// Enable Profiling Pull Mode
-	// router.Mount("/debug/pprof/", http.DefaultServeMux)
-
 	if profiling {
 		router.Use(k6.LabelsFromBaggageHandler)
+	} else {
+		// Enable Profiling Pull Mode
+		router.Mount("/debug/pprof/", http.DefaultServeMux)
 	}
 
 	return &Server{

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -15,7 +15,8 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
-	_ "net/http/pprof"
+
+	// _ "net/http/pprof"
 	"net/url"
 	"os"
 	"slices"
@@ -261,7 +262,7 @@ func NewServer(profiling bool, traceInstaller *TraceInstaller) *Server {
 	)
 
 	// Enable Profiling Pull Mode
-	router.Mount("/debug/pprof/", http.DefaultServeMux)
+	// router.Mount("/debug/pprof/", http.DefaultServeMux)
 
 	if profiling {
 		router.Use(k6.LabelsFromBaggageHandler)


### PR DESCRIPTION
Resolves #248 where a Panic occurs due to having conflicting routes with the new Pull Mode for Profiling. This only causes an issue when Profiling is already configured for the previous Push Mode.

The change that caused this was introduced in #230 

Cc: @ppcano 
