### PR TITLE
fix: fix default user when clearing ratings

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -871,7 +871,11 @@ func (s *Server) AddCatalogHandler(db *database.Catalog) {
 
 			updated, err := db.UpdateRating(r.Context(), user, &rating)
 			if err != nil {
-				s.writeJSONErrorResponse(w, r, err, http.StatusBadRequest)
+				if errors.Is(err, database.ErrGlobalOperationNotPermitted) {
+					s.writeJSONErrorResponse(w, r, err, http.StatusForbidden)
+				} else {
+					s.writeJSONErrorResponse(w, r, err, http.StatusBadRequest)
+				}
 				return
 			}
 
@@ -902,7 +906,11 @@ func (s *Server) AddCatalogHandler(db *database.Catalog) {
 
 			err := db.DeleteRatings(r.Context(), user)
 			if err != nil {
-				s.writeJSONErrorResponse(w, r, err, http.StatusBadRequest)
+				if errors.Is(err, database.ErrGlobalOperationNotPermitted) {
+					s.writeJSONErrorResponse(w, r, err, http.StatusForbidden)
+				} else {
+					s.writeJSONErrorResponse(w, r, err, http.StatusBadRequest)
+				}
 				return
 			}
 
@@ -924,7 +932,11 @@ func (s *Server) AddCatalogHandler(db *database.Catalog) {
 
 			err = db.DeleteRating(r.Context(), user, idParam)
 			if err != nil {
-				s.writeJSONErrorResponse(w, r, err, http.StatusBadRequest)
+				if errors.Is(err, database.ErrGlobalOperationNotPermitted) {
+					s.writeJSONErrorResponse(w, r, err, http.StatusForbidden)
+				} else {
+					s.writeJSONErrorResponse(w, r, err, http.StatusBadRequest)
+				}
 				return
 			}
 

--- a/pkg/web/src/routes/login/+page.svelte
+++ b/pkg/web/src/routes/login/+page.svelte
@@ -91,10 +91,23 @@
 	}
 
 	async function deleteRatings() {
-		await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/ratings`, {
+		const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/ratings`, {
 			method: 'DELETE',
 			credentials: 'same-origin'
 		});
+		
+		if (!res.ok) {
+			if (res.status === 403) {
+				const json = await res.json();
+				alert('Cannot clear ratings: The default user is not allowed to delete ratings. Please create your own user account.');
+			} else if (res.status === 401) {
+				alert('You need to be logged in to clear ratings.');
+			} else {
+				alert('Failed to clear ratings: ' + res.statusText);
+			}
+			return;
+		}
+		
 		location.reload();
 	}
 


### PR DESCRIPTION
The default user is not allowed to clear ratings. Currently the app simply reloads the page and silently fails. I have added a more sophisticated error handling to let user know what's wrong.