### PR TITLE
Update browser tests to use `getBy*` and fix browser tests

### DIFF
--- a/k6/browser/01.basic.js
+++ b/k6/browser/01.basic.js
@@ -27,7 +27,7 @@ export default async function () {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
-    await page.locator('//button[. = "Pizza, Please!"]').click();
+    await page.getByRole("button", { name: "Pizza, Please!" }).click();
     await page.waitForTimeout(500);
     await page.screenshot({ path: "screenshot.png" });
     checkData = await page.locator("div#recommendations").textContent();

--- a/k6/browser/01.basic.js
+++ b/k6/browser/01.basic.js
@@ -1,5 +1,5 @@
 import { browser } from "k6/browser";
-import { check } from "k6";
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:3333";
 
@@ -23,7 +23,7 @@ export default async function () {
 
     await page.goto(BASE_URL);
     checkData = await page.locator("h1").textContent();
-    check(page, {
+    check(checkData, {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
@@ -31,7 +31,7 @@ export default async function () {
     await page.waitForTimeout(500);
     await page.screenshot({ path: "screenshot.png" });
     checkData = await page.locator("div#recommendations").textContent();
-    check(page, {
+    check(checkData, {
       recommendation: checkData != "",
     });
   } finally {

--- a/k6/browser/02.cookies.js
+++ b/k6/browser/02.cookies.js
@@ -1,5 +1,5 @@
 import { browser } from "k6/browser";
-import { check } from "k6";
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:3333";
 

--- a/k6/browser/03.thresholds.js
+++ b/k6/browser/03.thresholds.js
@@ -30,7 +30,7 @@ export default async function () {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
-    await page.locator('//button[. = "Pizza, Please!"]').click();
+    await page.getByRole("button", { name: "Pizza, Please!" }).click();
     await page.waitForTimeout(500);
     await page.screenshot({ path: "screenshot.png" });
     checkData = await page.locator("div#recommendations").textContent();

--- a/k6/browser/03.thresholds.js
+++ b/k6/browser/03.thresholds.js
@@ -1,5 +1,5 @@
 import { browser } from "k6/browser";
-import { check } from "k6";
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:3333";
 
@@ -26,7 +26,7 @@ export default async function () {
   try {
     await page.goto(BASE_URL);
     checkData = await page.locator("h1").textContent();
-    check(page, {
+    check(checkData, {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
@@ -34,7 +34,7 @@ export default async function () {
     await page.waitForTimeout(500);
     await page.screenshot({ path: "screenshot.png" });
     checkData = await page.locator("div#recommendations").textContent();
-    check(page, {
+    check(checkData, {
       recommendation: checkData != "",
     });
   } finally {

--- a/k6/browser/04.scenarios.js
+++ b/k6/browser/04.scenarios.js
@@ -36,8 +36,8 @@ export async function admin() {
 
   try {
     await page.goto(`${BASE_URL}/admin`);
-    await page.locator('button[type="submit"]').click();
-    checkData = await page.locator('//*[text()="Logout"]').textContent();
+    await page.getByRole("button", { name: "Sign in" }).click();
+    checkData = await page.getByRole("button", { name: "Logout" }).textContent();
     check(page, {
       "logout button text": checkData == "Logout",
     });
@@ -56,7 +56,7 @@ export async function pizzaRecommendations() {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
-    await page.locator('//button[. = "Pizza, Please!"]').click();
+    await page.getByRole("button", { name: "Pizza, Please!" }).click();
     await page.waitForTimeout(500);
     await page.screenshot({ path: "screenshot.png" });
     checkData = await page.locator("div#recommendations").textContent();

--- a/k6/browser/04.scenarios.js
+++ b/k6/browser/04.scenarios.js
@@ -25,8 +25,8 @@ export const options = {
     },
   },
   thresholds: {
-    browser_web_vital_fcp: ["p(95) < 1000"],
-    browser_web_vital_lcp: ["p(95) < 2000"],
+    browser_web_vital_fcp: ["p(95) < 3000"],
+    browser_web_vital_lcp: ["p(95) < 4000"],
   },
 };
 

--- a/k6/browser/04.scenarios.js
+++ b/k6/browser/04.scenarios.js
@@ -1,5 +1,5 @@
 import { browser } from "k6/browser";
-import { check } from "k6";
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:3333";
 
@@ -38,7 +38,7 @@ export async function admin() {
     await page.goto(`${BASE_URL}/admin`);
     await page.getByRole("button", { name: "Sign in" }).click();
     checkData = await page.getByRole("button", { name: "Logout" }).textContent();
-    check(page, {
+    check(checkData, {
       "logout button text": checkData == "Logout",
     });
   } finally {
@@ -52,7 +52,7 @@ export async function pizzaRecommendations() {
   try {
     await page.goto(BASE_URL);
     checkData = await page.locator("h1").textContent();
-    check(page, {
+    check(checkData, {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
@@ -60,7 +60,7 @@ export async function pizzaRecommendations() {
     await page.waitForTimeout(500);
     await page.screenshot({ path: "screenshot.png" });
     checkData = await page.locator("div#recommendations").textContent();
-    check(page, {
+    check(checkData, {
       recommendation: checkData != "",
     });
   } finally {

--- a/k6/browser/04.scenarios.js
+++ b/k6/browser/04.scenarios.js
@@ -35,7 +35,7 @@ export async function admin() {
   const page = await browser.newPage();
 
   try {
-    await page.goto(`${BASE_URL}/admin`);
+    await page.goto(`${BASE_URL}/admin`, { waitUntil: "networkidle" });
     await page.getByRole("button", { name: "Sign in" }).click();
     checkData = await page.getByRole("button", { name: "Logout" }).textContent();
     check(checkData, {

--- a/k6/browser/05.custom-metrics.js
+++ b/k6/browser/05.custom-metrics.js
@@ -1,5 +1,5 @@
 import { browser } from "k6/browser";
-import { check } from "k6";
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { Trend } from "k6/metrics";
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:3333";
@@ -41,7 +41,7 @@ export async function admin() {
     await page.goto(`${BASE_URL}/admin`);
     await page.getByRole('button', { name: "Sign in" }).click();
     checkData = await page.getByRole('button', { name: "Logout" }).textContent();
-    check(page, {
+    check(checkData, {
       "logout button text": checkData == "Logout",
     });
   } finally {
@@ -56,7 +56,7 @@ export async function pizzaRecommendations() {
     await page.goto(BASE_URL);
     await page.evaluate(() => window.performance.mark('page-visit'));
     checkData = await page.locator("h1").textContent();
-    check(page, {
+    check(checkData, {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
@@ -66,7 +66,7 @@ export async function pizzaRecommendations() {
 
     page.evaluate(() => window.performance.mark("recommendations-returned"));
     checkData = await page.locator("div#recommendations").textContent();
-    check(page, {
+    check(checkData, {
       recommendation: checkData != "",
     });
     //Get time difference between visiting the page and pizza recommendations returned

--- a/k6/browser/05.custom-metrics.js
+++ b/k6/browser/05.custom-metrics.js
@@ -26,8 +26,8 @@ export const options = {
     },
   },
   thresholds: {
-    browser_web_vital_fcp: ["p(95) < 1000"],
-    browser_web_vital_lcp: ["p(95) < 2000"],
+    browser_web_vital_fcp: ["p(95) < 3000"],
+    browser_web_vital_lcp: ["p(95) < 4000"],
   },
 };
 

--- a/k6/browser/05.custom-metrics.js
+++ b/k6/browser/05.custom-metrics.js
@@ -39,8 +39,8 @@ export async function admin() {
 
   try {
     await page.goto(`${BASE_URL}/admin`);
-    await page.locator('button[type="submit"]').click();
-    checkData = await page.locator('//*[text()="Logout"]').textContent();
+    await page.getByRole('button', { name: "Sign in" }).click();
+    checkData = await page.getByRole('button', { name: "Logout" }).textContent();
     check(page, {
       "logout button text": checkData == "Logout",
     });
@@ -60,7 +60,7 @@ export async function pizzaRecommendations() {
       header: checkData == "Looking to break out of your pizza routine?",
     });
 
-    await page.locator('//button[. = "Pizza, Please!"]').click();
+    await page.getByRole("button", { name: "Pizza, Please!" }).click();
     await page.waitForTimeout(500);
     await page.screenshot({ path: "screenshot.png" });
 

--- a/k6/browser/05.custom-metrics.js
+++ b/k6/browser/05.custom-metrics.js
@@ -38,7 +38,7 @@ export async function admin() {
   const page = await browser.newPage();
 
   try {
-    await page.goto(`${BASE_URL}/admin`);
+    await page.goto(`${BASE_URL}/admin`, { waitUntil: "networkidle" });
     await page.getByRole('button', { name: "Sign in" }).click();
     checkData = await page.getByRole('button', { name: "Logout" }).textContent();
     check(checkData, {

--- a/k6/browser/06.page-objects.js
+++ b/k6/browser/06.page-objects.js
@@ -1,5 +1,5 @@
 import { browser } from "k6/browser";
-import { check } from "k6";
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { Trend } from "k6/metrics";
 
 import { LoginPage } from "./pages/login-page.js";

--- a/k6/browser/06.page-objects.js
+++ b/k6/browser/06.page-objects.js
@@ -46,7 +46,7 @@ export async function admin() {
     await loginPage.login();
 
     check(loginPage, {
-      "logout button text": loginPage.getLogoutButtonText() == "Logout",
+      "logout button text": await loginPage.getLogoutButtonText() == "Logout",
     });
   } finally {
     await page.close();
@@ -60,23 +60,23 @@ export async function pizzaRecommendations() {
 
   try {
     await recommendationsPage.goto(BASE_URL);
-    pageUtils.addPerformanceMark('page-visit');
+    await pageUtils.addPerformanceMark('page-visit');
 
     check(recommendationsPage, {
-      header: recommendationsPage.getHeadingTextContent() == "Looking to break out of your pizza routine?",
+      header: await recommendationsPage.getHeadingTextContent() == "Looking to break out of your pizza routine?",
     });
 
     await recommendationsPage.getPizzaRecommendation();
-    pageUtils.addPerformanceMark('recommendations-returned');
+    await pageUtils.addPerformanceMark('recommendations-returned');
 
     check(recommendationsPage, {
-      recommendation: recommendationsPage.getPizzaRecommendationsContent() != "",
+      recommendation: await recommendationsPage.getPizzaRecommendationsContent() != "",
     });
 
     //Get time difference between visiting the page and pizza recommendations returned
-    pageUtils.measurePerformance('total-action-time', 'page-visit', 'recommendations-returned')
+    await pageUtils.measurePerformance('total-action-time', 'page-visit', 'recommendations-returned')
 
-    const totalActionTime = pageUtils.getPerformanceDuration('total-action-time');
+    const totalActionTime = await pageUtils.getPerformanceDuration('total-action-time');
     myTrend.add(totalActionTime);
   } finally {
     await page.close();

--- a/k6/browser/06.page-objects.js
+++ b/k6/browser/06.page-objects.js
@@ -30,8 +30,8 @@ export const options = {
     },
   },
   thresholds: {
-    browser_web_vital_fcp: ["p(95) < 1000"],
-    browser_web_vital_lcp: ["p(95) < 2000"],
+    browser_web_vital_fcp: ["p(95) < 3000"],
+    browser_web_vital_lcp: ["p(95) < 4000"],
   }
 };
 

--- a/k6/browser/07.hybrid.js
+++ b/k6/browser/07.hybrid.js
@@ -54,8 +54,8 @@ export const options = {
   thresholds: {
     http_req_failed: ['rate<0.01'],
     http_req_duration: ['p(95)<500', 'p(99)<1000'],
-    browser_web_vital_fcp: ["p(95) < 1000"],
-    browser_web_vital_lcp: ["p(95) < 2000"],
+    browser_web_vital_fcp: ["p(95) < 3000"],
+    browser_web_vital_lcp: ["p(95) < 4000"],
   }
 };
 

--- a/k6/browser/07.hybrid.js
+++ b/k6/browser/07.hybrid.js
@@ -61,7 +61,7 @@ export const options = {
 
 const myTrend = new Trend('totalActionTime');
 
-export function getPizza() {
+export async function getPizza() {
   let restrictions = {
     maxCaloriesPerSlice: 500,
     mustBeVegetarian: false,
@@ -89,7 +89,7 @@ export async function admin() {
     await loginPage.login();
 
     check(loginPage, {
-      "logout button text": loginPage.getLogoutButtonText() == "Logout",
+      "logout button text": await loginPage.getLogoutButtonText() == "Logout",
     });
   } finally {
     await page.close();
@@ -103,23 +103,23 @@ export async function pizzaRecommendations() {
 
   try {
     await recommendationsPage.goto(BASE_URL);
-    pageUtils.addPerformanceMark('page-visit');
+    await pageUtils.addPerformanceMark('page-visit');
 
     check(recommendationsPage, {
-      header: recommendationsPage.getHeadingTextContent() == "Looking to break out of your pizza routine?",
+      header: await recommendationsPage.getHeadingTextContent() == "Looking to break out of your pizza routine?",
     });
 
     await recommendationsPage.getPizzaRecommendation();
-    pageUtils.addPerformanceMark('recommendations-returned');
+    await pageUtils.addPerformanceMark('recommendations-returned');
 
     check(recommendationsPage, {
-      recommendation: recommendationsPage.getPizzaRecommendationsContent() != "",
+      recommendation: await recommendationsPage.getPizzaRecommendationsContent() != "",
     });
 
     //Get time difference between visiting the page and pizza recommendations returned
-    pageUtils.measurePerformance('total-action-time', 'page-visit', 'recommendations-returned')
+    await pageUtils.measurePerformance('total-action-time', 'page-visit', 'recommendations-returned')
 
-    const totalActionTime = pageUtils.getPerformanceDuration('total-action-time');
+    const totalActionTime = await pageUtils.getPerformanceDuration('total-action-time');
     myTrend.add(totalActionTime);
   } finally {
     await page.close();

--- a/k6/browser/07.hybrid.js
+++ b/k6/browser/07.hybrid.js
@@ -1,5 +1,6 @@
 import { browser } from "k6/browser";
-import { check, sleep } from "k6";
+import { sleep } from "k6";
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import http from "k6/http";
 import { Trend } from "k6/metrics";
 

--- a/k6/browser/pages/login-page.js
+++ b/k6/browser/pages/login-page.js
@@ -1,8 +1,8 @@
 export class LoginPage {
   constructor(page) {
     this.page = page
-    this.submitButton = page.locator('button[type="submit"]');
-    this.logoutButton = page.locator('//*[text()="Logout"]');
+    this.submitButton = page.getByRole('button', { name: "Sign in" });
+    this.logoutButton = page.getByRole('button', { name: "Logout" });
   }
 
   async goto(baseURL) {

--- a/k6/browser/pages/login-page.js
+++ b/k6/browser/pages/login-page.js
@@ -6,7 +6,7 @@ export class LoginPage {
   }
 
   async goto(baseURL) {
-    await this.page.goto(`${baseURL}/admin`);
+    await this.page.goto(`${baseURL}/admin`, { waitUntil: "networkidle" });
   }
 
   async login() {

--- a/k6/browser/pages/page-utils.js
+++ b/k6/browser/pages/page-utils.js
@@ -3,20 +3,20 @@ export class PageUtils {
     this.page = page;
   }
 
-  addPerformanceMark(markName) {
-    this.page.evaluate(function (markName) {
+  async addPerformanceMark(markName) {
+    await this.page.evaluate(function (markName) {
       window.performance.mark(markName)
     }, markName);
   }
 
-  measurePerformance(performanceName, markName1, markName2) {
-    this.page.evaluate(function (performanceName, markName1, markName2) {
+  async measurePerformance(performanceName, markName1, markName2) {
+    await this.page.evaluate(function (performanceName, markName1, markName2) {
       window.performance.measure(performanceName, markName1, markName2)
     }, performanceName, markName1, markName2)
   }
 
-  getPerformanceDuration(performanceName) {
-    return this.page.evaluate(function (performanceName) {
+  async getPerformanceDuration(performanceName) {
+    return await this.page.evaluate(function (performanceName) {
       return JSON.parse(JSON.stringify(window.performance.getEntriesByName(performanceName)))[0].duration
     }, performanceName);
   }

--- a/k6/browser/pages/recommendations-page.js
+++ b/k6/browser/pages/recommendations-page.js
@@ -2,7 +2,7 @@ export class RecommendationsPage {
   constructor(page) {
     this.page = page
     this.headingTextContent = page.locator("h1");
-    this.getPizzaRecommendationsButton = page.locator('//button[. = "Pizza, Please!"]');
+    this.getPizzaRecommendationsButton = page.getByRole('button', { name: "Pizza, Please!" });
     this.pizzaRecommendations = page.locator("div#recommendations");
   }
 

--- a/k6/browser/pages/recommendations-page.js
+++ b/k6/browser/pages/recommendations-page.js
@@ -12,15 +12,15 @@ export class RecommendationsPage {
 
   async getPizzaRecommendation() {
     await this.getPizzaRecommendationsButton.click();
-    this.page.waitForTimeout(500);
-    this.page.screenshot({ path: "screenshot.png" });
+    await this.page.waitForTimeout(500);
+    await this.page.screenshot({ path: "screenshot.png" });
   }
 
-  getHeadingTextContent() {
-    return this.headingTextContent.textContent();
+  async getHeadingTextContent() {
+    return await this.headingTextContent.textContent();
   }
 
-  getPizzaRecommendationsContent() {
-    return this.pizzaRecommendations.textContent();
+  async getPizzaRecommendationsContent() {
+    return await this.pizzaRecommendations.textContent();
   }
 }


### PR DESCRIPTION
# What

- This updates the browser tests to use `getBy*` where possible, which is recommended over raw/naked selectors.
- It ensures that async APIs are correctly used with `async` and `await` keywords.
- It ensures that we use the async compatible `check`.
- Update web vital thresholds to mitigate threshold failures.
- Uses `networkidle` for admin page since `login` button doesn't work when clicked on too early 🤷 