### PR TITLE
Fix label to point to id of input

### DIFF
--- a/pkg/web/src/routes/admin/+page.svelte
+++ b/pkg/web/src/routes/admin/+page.svelte
@@ -119,7 +119,7 @@ function updateRecommendations() {
 					</h1>
 					<form class="space-y-4 md:space-y-6" on:submit|preventDefault={handleSubmit}>
 						<div>
-							<label for="text" class="block mb-2 text-sm font-medium text-gray-900"
+							<label for="username" class="block mb-2 text-sm font-medium text-gray-900"
 								>Username (hint: admin)</label
 							>
 							<input
@@ -132,7 +132,7 @@ function updateRecommendations() {
 							/>
 						</div>
 						<div>
-							<label for="text" class="block mb-2 text-sm font-medium text-gray-900"
+							<label for="password" class="block mb-2 text-sm font-medium text-gray-900"
 								>Password (hint: admin)</label
 							>
 							<input

--- a/pkg/web/src/routes/login/+page.svelte
+++ b/pkg/web/src/routes/login/+page.svelte
@@ -164,7 +164,7 @@ async function handleLogout() {
 					<form class="space-y-4 md:space-y-6" on:submit|preventDefault={handleSubmit}>
 						<input type="hidden" name="csrftoken" id="csrf-token" value="" />
 						<div>
-							<label for="text" class="block mb-2 text-sm font-medium text-gray-900"
+							<label for="username" class="block mb-2 text-sm font-medium text-gray-900"
 								>Username (hint: default)</label
 							>
 							<input
@@ -177,7 +177,7 @@ async function handleLogout() {
 							/>
 						</div>
 						<div>
-							<label for="text" class="block mb-2 text-sm font-medium text-gray-900"
+							<label for="password" class="block mb-2 text-sm font-medium text-gray-900"
 								>Password (hint: 12345678)</label
 							>
 							<input


### PR DESCRIPTION
# What

We've changing the `label` `for` attribute to point to the input that it is labelling by referencing its `id`.

# Why

Fixing a bug. Preventing k6 browser from correctly working with `getByLabel`.