### PR TITLE
Add `QUICKPIZZA_DELAY_*` env vars to inject delays

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,6 +2,9 @@ package util
 
 import (
 	"math/rand"
+	"os"
+	"strconv"
+	"time"
 )
 
 const (
@@ -18,4 +21,13 @@ func GenerateAlphaNumToken(length int) string {
 		data[i] = characters[rand.Intn(len(characters))]
 	}
 	return string(data)
+}
+
+// DelayIfEnvSet applies a delay in milliseconds if the specified environment variable is set.
+// The environment variable should contain an integer value representing milliseconds.
+func DelayIfEnvSet(envVarName string) {
+	if delayStr, ok := os.LookupEnv(envVarName); ok {
+		delayMs, _ := strconv.Atoi(delayStr)
+		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+	}
 }


### PR DESCRIPTION
Added `DelayIfEnvSet` function to allow injecting delays on several endpoints. This enables the QuickPizza demo to easily show how to find the slow-performance component with traces.

Currently, `DelayIfEnvSet` is used with the following env vars:

- `QUICKPIZZA_DELAY_COPY`: all copy endpoints, or individual endpoints with  `QUICKPIZZA_DELAY_COPY_API_QUOTES`, `QUICKPIZZA_DELAY_COPY_API_NAMES`, and  `QUICKPIZZA_DELAY_COPY_API_ADJECTIVES`.
   
- `QUICKPIZZA_DELAY_RECOMMENDATIONS`: all recomm endpoints, or individual with `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_GET`, and `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST`

- `QUICKPIZZA_DELAY_FRONTEND_CSS_ASSETS` or `QUICKPIZZA_DELAY_FRONTEND_PNG_ASSETS` for CSS or PNG assets respectively.

- ... we can extend its usage to other endpoints.


 Here's a screenshot with `QUICKPIZZA_DELAY_COPY` setup to `2000` (2 seconds delay).


<img width="930" height="874" alt="Screenshot 2025-10-10 at 19 13 43" src="https://github.com/user-attachments/assets/bdee2f6a-5c21-4908-82e2-7b17ecb7cfaf" />



