### PR TITLE
Fix OTEL setup when OTEL endpoint is not set

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,8 +43,8 @@ func main() {
 	otelInstaller := &qphttp.OTelInstaller{}
 
 	// TODO: use standard OTEL_EXPORTER_OTLP_ENDPOINT env var
-	otlpEndpoint, otelEnabled := os.LookupEnv("QUICKPIZZA_OTLP_ENDPOINT")
-	if otelEnabled {
+	otlpEndpoint, _ := os.LookupEnv("QUICKPIZZA_OTLP_ENDPOINT")
+	if otlpEndpoint != "" {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 


### PR DESCRIPTION
The current OpenTelemetry initialization logic fails in the following conditions:

- When `QUICKPIZZA_OTLP_ENDPOINT` is unset, QP crashes on startup with nil pointer panic.
- When `QUICKPIZZA_OTLP_ENDPOINT` is empty, traces are generated but fail to export, logging exported errors.

This PR fixes it:

- When `QUICKPIZZA_OTLP_ENDPOINT` is unset or empty, it creates no-op trace and metric providers that generate traces locally without attempting to export to remote endpoints
- When `QUICKPIZZA_OTLP_ENDPOINT` is set, it creates proper trace and metric providers that export traces to the configured endpoint.