### PR TITLE
Update pyroscope service name to match OTel service name

### DIFF
--- a/compose.grafana-cloud.microservices.yaml
+++ b/compose.grafana-cloud.microservices.yaml
@@ -48,6 +48,7 @@ services:
       QUICKPIZZA_ENABLE_CATALOG_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "catalog"
       QUICKPIZZA_OTEL_SERVICE_NAME: "catalog"
+      QUICKPIZZA_PYROSCOPE_NAME: "catalog"
 
   config:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -59,6 +60,7 @@ services:
       QUICKPIZZA_ENABLE_CONFIG_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "config"
       QUICKPIZZA_OTEL_SERVICE_NAME: "config"
+      QUICKPIZZA_PYROSCOPE_NAME: "config"
       # enable Faro integration
       QUICKPIZZA_CONF_FARO_URL: "${QUICKPIZZA_CONF_FARO_URL:-}"
       QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-}"
@@ -72,6 +74,7 @@ services:
       QUICKPIZZA_ENABLE_COPY_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "copy"
       QUICKPIZZA_OTEL_SERVICE_NAME: "copy"
+      QUICKPIZZA_PYROSCOPE_NAME: "copy"
 
   public-api:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -85,6 +88,7 @@ services:
       QUICKPIZZA_ENABLE_PUBLIC_API_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "public-api"
       QUICKPIZZA_OTEL_SERVICE_NAME: "public-api"
+      QUICKPIZZA_PYROSCOPE_NAME: "public-api"
 
   recommendations:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -96,6 +100,7 @@ services:
       QUICKPIZZA_ENABLE_RECOMMENDATIONS_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "recommendations"
       QUICKPIZZA_OTEL_SERVICE_NAME: "recommendations"
+      QUICKPIZZA_PYROSCOPE_NAME: "recommendations"
 
   ws:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -107,3 +112,4 @@ services:
       QUICKPIZZA_ENABLE_WS_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "ws"
       QUICKPIZZA_OTEL_SERVICE_NAME: "ws"
+      QUICKPIZZA_PYROSCOPE_NAME: "ws"

--- a/compose.grafana-cloud.monolithic.yaml
+++ b/compose.grafana-cloud.monolithic.yaml
@@ -37,6 +37,7 @@ services:
       QUICKPIZZA_ENABLE_ALL_SERVICES: 1 # 1 for monolithic mode
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "quickpizza"
       QUICKPIZZA_OTEL_SERVICE_NAME: "quickpizza"
+      QUICKPIZZA_PYROSCOPE_NAME: "quickpizza"
       # enable Faro integration
       QUICKPIZZA_CONF_FARO_URL: "${QUICKPIZZA_CONF_FARO_URL:-}"
       QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-}"

--- a/compose.grafana-local-stack.microservices.yaml
+++ b/compose.grafana-local-stack.microservices.yaml
@@ -52,6 +52,7 @@ services:
       QUICKPIZZA_ENABLE_CATALOG_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "catalog"
       QUICKPIZZA_OTEL_SERVICE_NAME: "catalog"
+      QUICKPIZZA_PYROSCOPE_NAME: "catalog"
 
   config:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -63,6 +64,7 @@ services:
       QUICKPIZZA_ENABLE_CONFIG_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "config"
       QUICKPIZZA_OTEL_SERVICE_NAME: "config"
+      QUICKPIZZA_PYROSCOPE_NAME: "config"
       # enable Faro integration
       QUICKPIZZA_CONF_FARO_URL: "${QUICKPIZZA_CONF_FARO_URL:-}"
       QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-}"
@@ -76,6 +78,7 @@ services:
       QUICKPIZZA_ENABLE_COPY_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "copy"
       QUICKPIZZA_OTEL_SERVICE_NAME: "copy"
+      QUICKPIZZA_PYROSCOPE_NAME: "copy"
 
   public-api:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -89,6 +92,7 @@ services:
       QUICKPIZZA_ENABLE_PUBLIC_API_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "public-api"
       QUICKPIZZA_OTEL_SERVICE_NAME: "public-api"
+      QUICKPIZZA_PYROSCOPE_NAME: "public-api"
 
   recommendations:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -100,6 +104,7 @@ services:
       QUICKPIZZA_ENABLE_RECOMMENDATIONS_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "recommendations"
       QUICKPIZZA_OTEL_SERVICE_NAME: "recommendations"
+      QUICKPIZZA_PYROSCOPE_NAME: "recommendations"
 
   ws:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
@@ -111,6 +116,7 @@ services:
       QUICKPIZZA_ENABLE_WS_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "ws"
       QUICKPIZZA_OTEL_SERVICE_NAME: "ws"
+      QUICKPIZZA_PYROSCOPE_NAME: "ws"
 
   loki:
     image: grafana/loki:3.4.3@sha256:5fe9fa99e9a747297cdf0239a5b25d192d8f668bd6505b09beef4dffcab5aac2

--- a/compose.grafana-local-stack.monolithic.yaml
+++ b/compose.grafana-local-stack.monolithic.yaml
@@ -41,6 +41,7 @@ services:
       QUICKPIZZA_ENABLE_ALL_SERVICES: 1 # 1 for monolithic mode
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "quickpizza"
       QUICKPIZZA_OTEL_SERVICE_NAME: "quickpizza"
+      QUICKPIZZA_PYROSCOPE_NAME: "quickpizza"
       # enable Faro integration
       QUICKPIZZA_CONF_FARO_URL: "${QUICKPIZZA_CONF_FARO_URL:-}"
       QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-}"

--- a/kubernetes/base/quickpizza/catalog.yaml
+++ b/kubernetes/base/quickpizza/catalog.yaml
@@ -44,6 +44,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/instance']
+            - name: QUICKPIZZA_PYROSCOPE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/instance']
 ---
 # Configures value for QUICKPIZZA_CATALOG_ENDPOINT (set in kustomization.yaml)
 apiVersion: v1

--- a/kubernetes/base/quickpizza/config.yaml
+++ b/kubernetes/base/quickpizza/config.yaml
@@ -44,6 +44,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/instance']
+            - name: QUICKPIZZA_PYROSCOPE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/instance']
 ---
 # Configures value for QUICKPIZZA_CONFIG_ENDPOINT (set in kustomization.yaml)
 apiVersion: v1

--- a/kubernetes/base/quickpizza/copy.yaml
+++ b/kubernetes/base/quickpizza/copy.yaml
@@ -44,6 +44,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/instance']
+            - name: QUICKPIZZA_PYROSCOPE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/instance']
 ---
 # Configures value for QUICKPIZZA_COPY_ENDPOINT (set in kustomization.yaml)
 apiVersion: v1

--- a/kubernetes/base/quickpizza/public-api.yaml
+++ b/kubernetes/base/quickpizza/public-api.yaml
@@ -44,6 +44,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/instance']
+            - name: QUICKPIZZA_PYROSCOPE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/instance']
 ---
 # PUBLIC ENDPOINT to serve API and static assets
 apiVersion: v1

--- a/kubernetes/base/quickpizza/recommendations.yaml
+++ b/kubernetes/base/quickpizza/recommendations.yaml
@@ -44,6 +44,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/instance']
+            - name: QUICKPIZZA_PYROSCOPE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/instance']
 ---
 # Configures value for QUICKPIZZA_RECOMMENDATIONS_ENDPOINT (set in kustomization.yaml)
 apiVersion: v1

--- a/kubernetes/base/quickpizza/ws.yaml
+++ b/kubernetes/base/quickpizza/ws.yaml
@@ -43,6 +43,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app.kubernetes.io/instance']
+            - name: QUICKPIZZA_PYROSCOPE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/instance']
 ---
 # Configures value for QUICKPIZZA_WS_ENDPOINT (set in kustomization.yaml)
 apiVersion: v1


### PR DESCRIPTION
This PR updates the k8s and docker compose manifests to set `QUICKPIZZA_PYROSCOPE_NAME` in a similar fashion to `QUICKPIZZA_OTEL_SERVICE_NAME`. This makes it easier to distinguish profiles in the Drilldown app, etc.