### PR TITLE
Enable Service Graph and instrumentation fixes

### DIFF
--- a/alloy/cloud.alloy
+++ b/alloy/cloud.alloy
@@ -95,11 +95,15 @@ pyroscope.scrape "application_containers" {
 // Traces
 otelcol.receiver.otlp "default" {
   // https://grafana.com/docs/alloy/latest/reference/components/otelcol.receiver.otlp/
-    
   // configures the default grpc endpoint "0.0.0.0:4317"
-  grpc { }
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+
   // configures the default http/protobuf endpoint "0.0.0.0:4318"
-  http { }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
     
   output {
     metrics = [otelcol.processor.resourcedetection.default.input]

--- a/alloy/cloud.alloy
+++ b/alloy/cloud.alloy
@@ -71,11 +71,24 @@ loki.source.docker "application_containers" {
   forward_to = [grafana_cloud.stack.receivers.logs]
 }
 
+// Filter to only scrape port 3333 for profiling.
+// Docker discovery creates separate targets for each exposed port (3333, 3334, 3335).
+// We only keep port 3333 where the HTTP pprof endpoints are available.
+// Ports 3334 and 3335 are gRPC servers without pprof Pull support.
+discovery.relabel "application_containers_profiles" {
+  rule {
+    source_labels = ["__meta_docker_port_private"]
+    regex         = "3333"
+    action        = "keep"
+  }
+  targets = discovery.relabel.application_containers.output
+}
+
 // Profiling Pull Mode
 pyroscope.scrape "application_containers" {
   // https://grafana.com/docs/pyroscope/latest/configure-client/grafana-alloy/go_pull/
   scrape_interval = "30s"
-  targets = discovery.relabel.application_containers.output
+  targets = discovery.relabel.application_containers_profiles.output
   forward_to = [grafana_cloud.stack.receivers.profiles]
 }
 

--- a/alloy/local-tempo.yaml
+++ b/alloy/local-tempo.yaml
@@ -50,8 +50,9 @@ storage:
     local:
       path: /var/tempo/blocks
 
+# enables the Drilldown Traces app
+# `service-graphs` and `span-metrics` via Alloy
 overrides:
   defaults:
     metrics_generator:
-      processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
-      generate_native_histograms: both
+      processors: [local-blocks]

--- a/alloy/local.alloy
+++ b/alloy/local.alloy
@@ -98,10 +98,12 @@ pyroscope.scrape "application_containers" {
 
 // Receive traces and metrics with OTEL setup
 otelcol.receiver.otlp "default" {
+  // configures the default grpc endpoint "0.0.0.0:4317"
   grpc {
     endpoint = "0.0.0.0:4317"
   }
 
+  // configures the default http/protobuf endpoint "0.0.0.0:4318"
   http {
     endpoint = "0.0.0.0:4318"
   }

--- a/alloy/local.alloy
+++ b/alloy/local.alloy
@@ -96,7 +96,7 @@ pyroscope.scrape "application_containers" {
 }
 
 
-// Receive traces
+// Receive traces and metrics with OTEL setup
 otelcol.receiver.otlp "default" {
   grpc {
     endpoint = "0.0.0.0:4317"
@@ -107,6 +107,8 @@ otelcol.receiver.otlp "default" {
   }
 
   output {
+    // Receive metrics
+    metrics = [otelcol.processor.batch.default.input]
     traces  = [
                // OTLP endpoint
                otelcol.processor.batch.default.input,
@@ -118,10 +120,10 @@ otelcol.receiver.otlp "default" {
   }
 }
 
-// Traces to OTLP endpoint
+// Traces to OTLP endpoint and Metrics to Prometheus
 otelcol.processor.batch "default" {
   output {
-    metrics = []
+    metrics = [otelcol.exporter.prometheus.local.input]
     logs = []
     traces = [
       otelcol.exporter.otlp.default.input,

--- a/alloy/local.alloy
+++ b/alloy/local.alloy
@@ -94,10 +94,12 @@ otelcol.receiver.otlp "default" {
   }
 
   output {
-    traces  = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input,
+               otelcol.processor.transform.spanmetrics.input]
   }
 }
 
+// Traces to OTLP endpoint
 otelcol.processor.batch "default" {
   output {
     metrics = []
@@ -118,4 +120,44 @@ otelcol.exporter.otlp "default" {
         insecure_skip_verify = true
     }
   }
+}
+
+// Traces to spanmetrics
+
+otelcol.processor.transform "spanmetrics" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      // We keep only the "service.name" and "special.attr" resource attributes,
+      // because they are the only ones which otelcol.connector.spanmetrics needs.
+      //
+      // There is no need to list "span.name", "span.kind", and "status.code"
+      // here because they are properties of the span (and not resource attributes):
+      // https://github.com/open-telemetry/opentelemetry-proto/blob/v1.0.0/opentelemetry/proto/trace/v1/trace.proto
+      `keep_keys(attributes, ["service.name", "special.attr"])`,
+    ]
+  }
+
+  output {
+    traces  = [otelcol.connector.spanmetrics.default.input]
+  }
+}
+
+otelcol.connector.spanmetrics "default" {
+  histogram {
+    explicit {}
+  }
+
+  dimension {
+    name = "special.attr"
+  }
+  output {
+    metrics = [otelcol.exporter.prometheus.local.input]
+  }
+}
+
+otelcol.exporter.prometheus "local" {
+  forward_to = [prometheus.remote_write.local.receiver]
 }

--- a/alloy/local.alloy
+++ b/alloy/local.alloy
@@ -76,10 +76,22 @@ pyroscope.write "local" {
        url = env("PROFILES_ENDPOINT")
    }
 }
+// Filter to only scrape port 3333 for profiling.
+// Docker discovery creates separate targets for each exposed port (3333, 3334, 3335).
+// We only keep port 3333 where the HTTP pprof endpoints are available.
+// Ports 3334 and 3335 are gRPC servers without pprof Pull support.
+discovery.relabel "application_containers_profiles" {
+  rule {
+    source_labels = ["__meta_docker_port_private"]
+    regex         = "3333"
+    action        = "keep"
+  }
+  targets = discovery.relabel.application_containers.output
+}
 pyroscope.scrape "application_containers" {
   // https://grafana.com/docs/pyroscope/latest/configure-client/grafana-alloy/go_pull/
   scrape_interval = "30s"
-  targets = discovery.relabel.application_containers.output
+  targets = discovery.relabel.application_containers_profiles.output
   forward_to = [pyroscope.write.local.receiver]
 }
 

--- a/alloy/local.alloy
+++ b/alloy/local.alloy
@@ -53,7 +53,7 @@ prometheus.remote_write "local" {
   }
 }
 prometheus.scrape "application_containers" {
-  scrape_interval = "60s"
+  scrape_interval = "10s"
   targets = discovery.relabel.application_containers.output
   forward_to = [prometheus.remote_write.local.receiver]
 }
@@ -83,6 +83,7 @@ pyroscope.scrape "application_containers" {
   forward_to = [pyroscope.write.local.receiver]
 }
 
+
 // Receive traces
 otelcol.receiver.otlp "default" {
   grpc {
@@ -94,8 +95,14 @@ otelcol.receiver.otlp "default" {
   }
 
   output {
-    traces  = [otelcol.processor.batch.default.input,
-               otelcol.processor.transform.spanmetrics.input]
+    traces  = [
+               // OTLP endpoint
+               otelcol.processor.batch.default.input,
+               // ServiceGraph
+               otelcol.connector.servicegraph.default.input,
+               // SpamMetrics
+               otelcol.processor.transform.spanmetrics.input,
+               ]
   }
 }
 
@@ -109,8 +116,6 @@ otelcol.processor.batch "default" {
     ]
   }
 }
-
-// Collect profiles
 otelcol.exporter.otlp "default" {
   client {
     // TODO: Replace this with the endpoint for your trace receiver
@@ -123,7 +128,6 @@ otelcol.exporter.otlp "default" {
 }
 
 // Traces to spanmetrics
-
 otelcol.processor.transform "spanmetrics" {
   error_mode = "ignore"
 
@@ -146,13 +150,23 @@ otelcol.processor.transform "spanmetrics" {
 }
 
 otelcol.connector.spanmetrics "default" {
+  metrics_flush_interval = "10s"
   histogram {
     explicit {}
   }
-
   dimension {
     name = "special.attr"
   }
+  output {
+    metrics = [otelcol.exporter.prometheus.local.input]
+  }
+}
+
+// Traces to servicegraph metrics
+// https://grafana.com/docs/tempo/latest/metrics-from-traces/service_graphs/enable-service-graphs/
+otelcol.connector.servicegraph "default" {
+  metrics_flush_interval = "10s"
+  dimensions = ["http.method", "http.target"]
   output {
     metrics = [otelcol.exporter.prometheus.local.input]
   }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,7 @@ func main() {
 	// If QUICKPIZZA_PYROSCOPE_ENDPOINT is set, profiling in push mode will be enabled.
 	profilingConfig, profilingEnabled := envPyroscopeConfig()
 	if profilingEnabled {
-		slog.Debug("enabling Pyroscope profiling in push mode")
+		slog.Info("enabling Pyroscope profiling in Push mode")
 
 		runtime.SetMutexProfileFraction(5)
 		runtime.SetBlockProfileRate(5)

--- a/compose.grafana-cloud.microservices.yaml
+++ b/compose.grafana-cloud.microservices.yaml
@@ -25,6 +25,8 @@ services:
       - --stability.level=public-preview
     ports:
       - "12345:12345"
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
     environment:
       QUICKPIZZA_HOST: public-api:3333
       # must be set with an .env file

--- a/compose.grafana-cloud.monolithic.yaml
+++ b/compose.grafana-cloud.monolithic.yaml
@@ -14,6 +14,8 @@ services:
       - --stability.level=public-preview
     ports:
       - "12345:12345"
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
     environment:
       QUICKPIZZA_HOST: quickpizza:3333
       # must be set with an .env file

--- a/compose.grafana-local-stack.microservices.yaml
+++ b/compose.grafana-local-stack.microservices.yaml
@@ -25,6 +25,8 @@ services:
       - --stability.level=public-preview
     ports:
       - "12345:12345"
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
     environment:
       QUICKPIZZA_HOST: quickpizza:3333
       METRICS_ENDPOINT: http://prometheus:9090/api/v1/write
@@ -147,9 +149,7 @@ services:
     volumes:
       - ./alloy/local-tempo.yaml:/etc/tempo.yaml
     ports:
-      - "3200:3200"
-      - "4317:4317"
-      - "4318:4318"
+      - "3200:3200" # Tempo API/UI
     depends_on:
       - prometheus
 

--- a/compose.grafana-local-stack.microservices.yaml
+++ b/compose.grafana-local-stack.microservices.yaml
@@ -63,9 +63,6 @@ services:
       QUICKPIZZA_ENABLE_CONFIG_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "config"
       QUICKPIZZA_OTEL_SERVICE_NAME: "config"
-      # enable Faro integration
-      QUICKPIZZA_CONF_FARO_URL: "${QUICKPIZZA_CONF_FARO_URL:-}"
-      QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-}"
   copy:
     image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:latest@sha256:9067de15119819a3ef17676b3245279937d9d9ef50e81a2ba0a8a30095d7bfce}
     container_name: copy

--- a/compose.grafana-local-stack.microservices.yaml
+++ b/compose.grafana-local-stack.microservices.yaml
@@ -142,7 +142,7 @@ services:
       - "4040:4040"
 
   tempo:
-    image: grafana/tempo:2.8.1@sha256:bc9245fe3da4e63dc4c6862d9c2dad9bcd8be13d0ba4f7705fa6acda4c904d0e
+    image: grafana/tempo:2.9.0@sha256:65a5789759435f1ef696f1953258b9bbdb18eb571d5ce711ff812d2e128288a4
     container_name: tempo
     labels:
       - "service.type=instrumentation"

--- a/compose.grafana-local-stack.monolithic.yaml
+++ b/compose.grafana-local-stack.monolithic.yaml
@@ -41,9 +41,6 @@ services:
       QUICKPIZZA_ENABLE_ALL_SERVICES: 1 # 1 for monolithic mode
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "quickpizza"
       QUICKPIZZA_OTEL_SERVICE_NAME: "quickpizza"
-      # enable Faro integration
-      QUICKPIZZA_CONF_FARO_URL: "${QUICKPIZZA_CONF_FARO_URL:-}"
-      QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-}"
       # Enable logging. Possible values: error, warn, debug. Default: info
       # QUICKPIZZA_LOG_LEVEL: debug
 
@@ -77,7 +74,7 @@ services:
       - "4040:4040"
 
   tempo:
-    image: grafana/tempo:2.8.1@sha256:bc9245fe3da4e63dc4c6862d9c2dad9bcd8be13d0ba4f7705fa6acda4c904d0e
+    image: grafana/tempo:2.9.0@sha256:65a5789759435f1ef696f1953258b9bbdb18eb571d5ce711ff812d2e128288a4
     container_name: tempo
     labels:
       - "service.type=instrumentation"

--- a/compose.grafana-local-stack.monolithic.yaml
+++ b/compose.grafana-local-stack.monolithic.yaml
@@ -14,6 +14,8 @@ services:
       - --stability.level=public-preview
     ports:
       - "12345:12345"
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
     environment:
       QUICKPIZZA_HOST: quickpizza:3333
       METRICS_ENDPOINT: http://prometheus:9090/api/v1/write
@@ -82,9 +84,7 @@ services:
     volumes:
       - ./alloy/local-tempo.yaml:/etc/tempo.yaml
     ports:
-      - "3200:3200"
-      - "4317:4317"
-      - "4318:4318"
+      - "3200:3200" # Tempo API/UI
     depends_on:
       - prometheus
 

--- a/grafana/datasources/datasource.yaml
+++ b/grafana/datasources/datasource.yaml
@@ -1,4 +1,4 @@
-# For configuration options, see 
+# For configuration options, see
 #   https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
 
 apiVersion: 1
@@ -6,6 +6,7 @@ apiVersion: 1
 datasources:
   - name: prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     orgId: 1
     url: http://prometheus:9090
@@ -18,6 +19,7 @@ datasources:
     editable: false
   - name: Tempo
     type: tempo
+    uid: tempo
     access: proxy
     orgId: 1
     url: http://tempo:3200
@@ -26,18 +28,23 @@ datasources:
     version: 1
     editable: false
     apiVersion: 1
-    uid: tempo
+    jsonData:
+      # activate service map and node graph features (required Alloy config)
+      serviceMap:
+        datasourceUid: "prometheus"
+      nodeGraph:
+        enabled: true
   - name: Pyroscope
-    type: 'phlare'
-    access: 'proxy'
-    orgId: 1
+    type: "phlare"
     uid: pyroscope
+    access: "proxy"
+    orgId: 1
     url: http://pyroscope:4040
     isDefault: false
     editable: false
   - name: Loki
     type: loki
-    access: proxy 
+    access: proxy
     orgId: 1
     url: http://loki:3100
     basicAuth: false

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -263,7 +263,7 @@ func NewServer(profiling bool, traceInstaller *OTelInstaller) *Server {
 	if profiling {
 		router.Use(k6.LabelsFromBaggageHandler)
 	} else {
-		// Enable Profiling Pull Mode
+		slog.Info("enabling Pyroscope profiling in Pull mode")
 		router.Mount("/debug/pprof/", http.DefaultServeMux)
 	}
 


### PR DESCRIPTION
Local Docker Compose

- Enable Tempo service graph (node graph) via Alloy setup
- Scrape only port 3333 for profiling
- Alloy handle OTEL metrics

Cloud Docker Compose
- Scrape only port 3333 for profiling
