### PR TITLE
OSS Alloy setup generates `traces_span_metrics_duration_seconds` (not milliseconds)

### DIFF
--- a/alloy/local.alloy
+++ b/alloy/local.alloy
@@ -128,6 +128,10 @@ otelcol.receiver.otlp "default" {
 otelcol.connector.spanmetrics "default" {
   metrics_flush_interval = "10s"
   histogram {
+    // `s` is the unit used by Application Observability
+    // https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/metrics-labels/
+    // this creates `traces_span_metrics_duration_seconds` instead of `traces_span_metrics_duration_milliseconds`
+    unit = "s"
     explicit {
       buckets = ["50ms", "100ms", "250ms", "1s", "5s", "10s"]
     }


### PR DESCRIPTION
OSS Alloy setup generates `traces_span_metrics_duration_seconds` (not milliseconds)