### PR TITLE
feat(chaos): add percentage-based random failure injection

### DIFF
--- a/alloy/local-tempo.yaml
+++ b/alloy/local-tempo.yaml
@@ -31,6 +31,7 @@ compactor:
 
 metrics_generator:
   registry:
+    collection_interval: 5s
     external_labels:
       source: tempo
       cluster: docker-compose

--- a/docs/inject-errors.md
+++ b/docs/inject-errors.md
@@ -27,6 +27,7 @@ The following environment variables are supported:
 - **QUICKPIZZA_DELAY_FRONTEND_CSS_ASSETS**: Adds delay when serving CSS assets
 - **QUICKPIZZA_DELAY_FRONTEND_PNG_ASSETS**: Adds delay when serving PNG image assets
 
+- **QUICKPIZZA_FAIL_RATE_RECOMMENDATIONS_API_PIZZA_POST**: Set to a number to fail `<number>%` of Pizza POST requests randomly.
 
 ## Using HTTP Headers
 

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1280,6 +1280,12 @@ func (s *Server) AddRecommendations(catalogClient CatalogClient, copyClient Copy
 		r.Post("/api/pizza", func(w http.ResponseWriter, r *http.Request) {
 
 			util.DelayIfEnvSet("QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST")
+
+			if util.FailRandomlyIfEnvSet("QUICKPIZZA_FAIL_RATE_RECOMMENDATIONS_API_PIZZA_POST") {
+				s.log.ErrorContext(r.Context(), "Simulated random failure: Pizza service temporarily unavailable")
+				s.writeJSONErrorResponse(w, r, errors.New("Pizza service temporarily unavailable"), http.StatusServiceUnavailable)
+				return
+			}
 			// Add request context to catalog and copy clients. This context contains a reference to the tracer used
 			// by the server (if any), which allows clients to both generate traces for outgoing client-type traces
 			// without explicitly configuring a tracer, and to link said client traces with the server trace that is

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -31,3 +31,20 @@ func DelayIfEnvSet(envVarName string) {
 		time.Sleep(time.Duration(delayMs) * time.Millisecond)
 	}
 }
+
+// FailRandomlyIfEnvSet checks if this request should fail based on a random percentage.
+// The environment variable should contain an integer value between 0 and 100 representing the failure rate percentage.
+// Invalid values are treated as 0 (no failures).
+func FailRandomlyIfEnvSet(envVarName string) bool {
+	rateStr, ok := os.LookupEnv(envVarName)
+	if !ok {
+		return false
+	}
+
+	rate, err := strconv.Atoi(rateStr)
+	if err != nil || rate < 0 || rate > 100 {
+		return false
+	}
+
+	return rand.Intn(100) < rate
+}

--- a/pkg/web/src/routes/+page.svelte
+++ b/pkg/web/src/routes/+page.svelte
@@ -44,6 +44,7 @@ var pizzaCount = 0;
 let restrictions = defaultRestrictions;
 var advanced = false;
 var rateResult = null;
+var errorResult = null;
 
 $: if (advanced) {
 	pizza = '';
@@ -145,8 +146,17 @@ async function getPizza() {
 		},
 	});
 	const json = await res.json();
-	pizza = json;
+	
 	rateResult = null;
+	errorResult = null;
+	if (!res.ok) {
+		pizza = '';
+		errorResult = json.error || 'Failed to get pizza recommendation. Please try again.';
+		faro.api.pushError(new Error(errorResult));
+		return;
+	}
+	
+	pizza = json;
 	if (socket.readyState <= 1) {
 		socket.send(
 			JSON.stringify({
@@ -331,6 +341,13 @@ async function getTools() {
 				/>
 			</ToggleConfetti>
 			<p />
+			{#if errorResult}
+				<div class="mt-4">
+					<span class="bg-red-100 text-red-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded" id="error-message"
+						>{errorResult}</span
+					>
+				</div>
+			{/if}
 			{#if pizzaCount > 0 && !pizza['pizza']}
 				<div class="mt-4">
 					<span class="bg-purple-100 text-purple-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded"


### PR DESCRIPTION

Introduce a new environment variable `QUICKPIZZA_FAIL_RATE_RECOMMENDATIONS_API_PIZZA_POST` 
that accepts values 0-100 to simulate random failures in the pizza recommendations endpoint.

Changes:
- Add util.FailRandomlyIfEnvSet() helper function
- Return 503 Service Unavailable with JSON error on simulated failures
- Display error messages to users in frontend with red banner
- Enable chaos engineering and resilience testing scenarios