### PR TITLE
Fix Alloy setup to generate `job` label

### DIFF
--- a/alloy/cloud.alloy
+++ b/alloy/cloud.alloy
@@ -22,13 +22,16 @@ discovery.docker "application_containers" {
 
 // set expected labels
 discovery.relabel "application_containers" {
+  // Application Observability expects `job` to be `$service.namespace/$service.name`
+  // Reads from service.namespace Docker label and container name to build: namespace/service-name
   rule {
     target_label = "job"
     source_labels = [
+      "__meta_docker_container_label_service_namespace",
       "__meta_docker_container_name",
     ]
-    regex = "/(.*)"
-    replacement = "quickpizza/${1}"
+    regex = "([^;]+);/(.*)"
+    replacement = "${1}/${2}"
   }
   rule {
     target_label = "instance"
@@ -40,12 +43,16 @@ discovery.relabel "application_containers" {
   }
   rule {
     target_label = "service_namespace"
-    replacement = "quickpizza"
+    source_labels = [
+      "__meta_docker_container_label_service_namespace",
+    ]
   }
   // the `namespace` label is for visualizing Profiles in Application Observability
   rule {
     target_label = "namespace"
-    replacement = "quickpizza"
+    source_labels = [
+      "__meta_docker_container_label_service_namespace",
+    ]
   }
   rule {
     target_label = "service_name"

--- a/alloy/local.alloy
+++ b/alloy/local.alloy
@@ -9,13 +9,16 @@ discovery.docker "application_containers" {
 
 // set expected labels
 discovery.relabel "application_containers" {
+  // Application Observability expects `job` to be `$service.namespace/$service.name`
+  // Reads from service.namespace Docker label and container name to build: namespace/service-name
   rule {
     target_label = "job"
     source_labels = [
+      "__meta_docker_container_label_service_namespace",
       "__meta_docker_container_name",
     ]
-    regex = "/(.*)"
-    replacement = "quickpizza/${1}"
+    regex = "([^;]+);/(.*)"
+    replacement = "${1}/${2}"
   }
   rule {
     target_label = "instance"
@@ -27,12 +30,16 @@ discovery.relabel "application_containers" {
   }
   rule {
     target_label = "service_namespace"
-    replacement = "quickpizza"
+    source_labels = [
+      "__meta_docker_container_label_service_namespace",
+    ]
   }
   // the `namespace` label is for visualizing Profiles in Application Observability
   rule {
     target_label = "namespace"
-    replacement = "quickpizza"
+    source_labels = [
+      "__meta_docker_container_label_service_namespace",
+    ]
   }
   rule {
     target_label = "service_name"

--- a/compose.grafana-cloud.microservices.yaml
+++ b/compose.grafana-cloud.microservices.yaml
@@ -47,6 +47,7 @@ services:
     container_name: catalog
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_CATALOG_SERVICE: "1"
@@ -58,6 +59,7 @@ services:
     container_name: config
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_CONFIG_SERVICE: "1"
@@ -71,6 +73,7 @@ services:
     container_name: copy
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_COPY_SERVICE: "1"
@@ -82,6 +85,7 @@ services:
     container_name: public-api
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     ports:
       - "3333:3333"
     environment:
@@ -95,6 +99,7 @@ services:
     container_name: recommendations
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_RECOMMENDATIONS_SERVICE: "1"
@@ -106,6 +111,7 @@ services:
     container_name: ws
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_WS_SERVICE: "1"

--- a/compose.grafana-cloud.monolithic.yaml
+++ b/compose.grafana-cloud.monolithic.yaml
@@ -32,6 +32,7 @@ services:
     container_name: quickpizza
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     ports:
       - "3333:3333"
     environment:

--- a/compose.grafana-local-stack.microservices.yaml
+++ b/compose.grafana-local-stack.microservices.yaml
@@ -51,6 +51,7 @@ services:
     container_name: catalog
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_CATALOG_SERVICE: "1"
@@ -62,6 +63,7 @@ services:
     container_name: config
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_CONFIG_SERVICE: "1"
@@ -72,6 +74,7 @@ services:
     container_name: copy
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_COPY_SERVICE: "1"
@@ -83,6 +86,7 @@ services:
     container_name: public-api
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     ports:
       - "3333:3333"
     environment:
@@ -96,6 +100,7 @@ services:
     container_name: recommendations
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_RECOMMENDATIONS_SERVICE: "1"
@@ -107,6 +112,7 @@ services:
     container_name: ws
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     environment:
       <<: *quickpizza-env-common
       QUICKPIZZA_ENABLE_WS_SERVICE: "1"

--- a/compose.grafana-local-stack.monolithic.yaml
+++ b/compose.grafana-local-stack.monolithic.yaml
@@ -36,6 +36,7 @@ services:
     container_name: quickpizza
     labels:
       - "service.type=application"
+      - "service.namespace=${SERVICE_NAMESPACE:-quickpizza}"
     ports:
       - "3333:3333"
     environment:

--- a/kubernetes/cloud/config/config.alloy
+++ b/kubernetes/cloud/config/config.alloy
@@ -27,7 +27,7 @@ discovery.relabel "application_pods" {
     target_label = "job"
     separator = "/"
     source_labels = [
-      "__meta_kubernetes_pod_label_app_k8s_io_name",
+      "__meta_kubernetes_namespace",
       "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
     ]
   }
@@ -40,16 +40,16 @@ discovery.relabel "application_pods" {
   rule {
     target_label = "service_namespace"
     source_labels = [
-      // quickpizza
-      "__meta_kubernetes_pod_label_app_k8s_io_name",
+      // The Kubernetes namespace where the pod is running
+      "__meta_kubernetes_namespace",
     ]
   }
   // the `namespace` label is for visualizing Profiles in Application Observability
   rule {
     target_label = "namespace"
     source_labels = [
-      // quickpizza
-      "__meta_kubernetes_pod_label_app_k8s_io_name",
+      // The Kubernetes namespace where the pod is running
+      "__meta_kubernetes_namespace",
     ]
   }
   rule {


### PR DESCRIPTION
The Alloy configuration was incorrectly using `__meta_kubernetes_pod_label_app_k8s_io_name` to populate `service_namespace` and `namespace` labels. This label contains the application name (`quickpizza`), not the Kubernetes namespace.

Similarly, the Docker Compose setup hardcoded the namespace value instead of making it configurable.


