### PR TITLE
chore: Bump Faro Instrumentation to v2.0.2

### DIFF
--- a/pkg/web/package-lock.json
+++ b/pkg/web/package-lock.json
@@ -14,8 +14,8 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.2.4",
-				"@grafana/faro-web-sdk": "1.18.2",
-				"@grafana/faro-web-tracing": "1.18.2",
+				"@grafana/faro-web-sdk": "2.0.2",
+				"@grafana/faro-web-tracing": "2.0.2",
 				"@sveltejs/adapter-auto": "6.1.0",
 				"@sveltejs/adapter-static": "3.0.9",
 				"@sveltejs/kit": "2.37.0",
@@ -636,43 +636,43 @@
 			}
 		},
 		"node_modules/@grafana/faro-core": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.18.2.tgz",
-			"integrity": "sha512-+yHUfxvVgEkd3WnhEKQMWAyZ+qB2fvtCqbmngcU+VpCVufWhT480eqc46Gpz5GdhupLNPQu+FLhjyD4baX/owQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.0.2.tgz",
+			"integrity": "sha512-dUcQBUDzvWmDbVDlYYEmVyjxZJjqC8syCuE/YWDJp/Zps9DkDH5CdF5kWuSb3cCm6U1iTo9czDkORPj0KEN9WQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/otlp-transformer": "^0.201.0"
+				"@opentelemetry/otlp-transformer": "^0.208.0"
 			}
 		},
 		"node_modules/@grafana/faro-web-sdk": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.18.2.tgz",
-			"integrity": "sha512-tQYMJ1iOF2MTCACB05cUk3E0bP6Uj0zmSvfWyyArjQfyMWs/TW++cKhxGFKDOn7t/bj1sTvk3QqP0b7ecL5qrw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.0.2.tgz",
+			"integrity": "sha512-Tn5XUBfmEOXexFGRVmtR1JqyoUWU0luw1T27p9vwBCAg6X5yCVOf7N73ctIZ+WD7eS1DCLdAGT8ehx44WXgyeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grafana/faro-core": "^1.18.2",
+				"@grafana/faro-core": "^2.0.2",
 				"ua-parser-js": "^1.0.32",
-				"web-vitals": "^4.0.1"
+				"web-vitals": "^5.0.3"
 			}
 		},
 		"node_modules/@grafana/faro-web-tracing": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.18.2.tgz",
-			"integrity": "sha512-RqvixKN31RLXEo34ewDE2wQru3DMeQkYf4mh3SkQkFXtO8QToTHbOip8F0um0bO97+cJF9F8ArC5B3pg9KV9zA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-2.0.2.tgz",
+			"integrity": "sha512-jFKpXkAGI4SO1wlDQfZ6I0ZBeGq1VykT4TiGWFY7VnMnQZeiEUA/KfpJpEya+CdkDmd+c9hiBmSZDLzplu8dNA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grafana/faro-web-sdk": "^1.18.2",
+				"@grafana/faro-web-sdk": "^2.0.2",
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/exporter-trace-otlp-http": "^0.201.0",
-				"@opentelemetry/instrumentation": "^0.201.0",
-				"@opentelemetry/instrumentation-fetch": "^0.201.0",
-				"@opentelemetry/instrumentation-xml-http-request": "^0.201.0",
-				"@opentelemetry/otlp-transformer": "^0.201.0",
+				"@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
+				"@opentelemetry/instrumentation": "^0.208.0",
+				"@opentelemetry/instrumentation-fetch": "^0.208.0",
+				"@opentelemetry/instrumentation-xml-http-request": "^0.208.0",
+				"@opentelemetry/otlp-transformer": "^0.208.0",
 				"@opentelemetry/resources": "^2.0.0",
 				"@opentelemetry/sdk-trace-web": "^2.0.0",
 				"@opentelemetry/semantic-conventions": "^1.32.0"
@@ -773,9 +773,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/api-logs": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.201.1.tgz",
-			"integrity": "sha512-IxcFDP1IGMDemVFG2by/AMK+/o6EuBQ8idUq3xZ6MxgQGeumYZuX5OwR0h9HuvcUc/JPjQGfU5OHKIKYDJcXeA==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -786,9 +786,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-			"integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -802,17 +802,17 @@
 			}
 		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-http": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.201.1.tgz",
-			"integrity": "sha512-Nw3pIqATC/9LfSGrMiQeeMQ7/z7W2D0wKPxtXwAcr7P64JW7KSH4YSX7Ji8Ti3MmB79NQg6imdagfegJDB0rng==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.208.0.tgz",
+			"integrity": "sha512-jbzDw1q+BkwKFq9yxhjAJ9rjKldbt5AgIy1gmEIJjEV/WRxQ3B6HcLVkwbjJ3RcMif86BDNKR846KJ0tY0aOJA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/otlp-exporter-base": "0.201.1",
-				"@opentelemetry/otlp-transformer": "0.201.1",
-				"@opentelemetry/resources": "2.0.1",
-				"@opentelemetry/sdk-trace-base": "2.0.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/otlp-exporter-base": "0.208.0",
+				"@opentelemetry/otlp-transformer": "0.208.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/sdk-trace-base": "2.2.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -822,17 +822,15 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.201.1.tgz",
-			"integrity": "sha512-6EOSoT2zcyBM3VryAzn35ytjRrOMeaWZyzQ/PHVfxoXp5rMf7UUgVToqxOhQffKOHtC7Dma4bHt+DuwIBBZyZA==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
+			"integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.201.1",
-				"@types/shimmer": "^1.2.0",
-				"import-in-the-middle": "^1.8.1",
-				"require-in-the-middle": "^7.1.1",
-				"shimmer": "^1.2.1"
+				"@opentelemetry/api-logs": "0.208.0",
+				"import-in-the-middle": "^2.0.0",
+				"require-in-the-middle": "^8.0.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -842,15 +840,15 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-fetch": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.201.1.tgz",
-			"integrity": "sha512-ZZZyQP+OYpMTK/Dm7j8W28GBLbtfe5r7rj+dAuhCQ5ELShJ4TUM0Ykcj2Oq4++2APeOzy8L6KkCukwtERdxzyQ==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.208.0.tgz",
+			"integrity": "sha512-zgStoUfNF1xH9bCq539k1aeieKxPiAvBo5gKipQ9fIt+eJsFvqGcSzrrDX+OYgpIPW/IVNgWBoOw6zVmKwgNwQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/instrumentation": "0.201.1",
-				"@opentelemetry/sdk-trace-web": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/instrumentation": "0.208.0",
+				"@opentelemetry/sdk-trace-web": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -861,15 +859,15 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-xml-http-request": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.201.1.tgz",
-			"integrity": "sha512-jh6KmoflVJo0SGK4fZupIbhIdw8lzfgiMLwUEetVMCJTkUStcZ1asWoZwV4r/SINnNE1oQntm+3LnO1jnUq6uw==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.208.0.tgz",
+			"integrity": "sha512-me0knebxJxnzis73p5/ZQgdLNG6nsUXMsDR/dZk+BPOiNyd3Me9ye2wVM06JlcLA54w4JESw6wMTNi4lMhowFQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/instrumentation": "0.201.1",
-				"@opentelemetry/sdk-trace-web": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/instrumentation": "0.208.0",
+				"@opentelemetry/sdk-trace-web": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -880,14 +878,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.201.1.tgz",
-			"integrity": "sha512-FiS/mIWmZXyRxYGyXPHY+I/4+XrYVTD7Fz/zwOHkVPQsA1JTakAOP9fAi6trXMio0dIpzvQujLNiBqGM7ExrQw==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+			"integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/otlp-transformer": "0.201.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/otlp-transformer": "0.208.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -897,18 +895,18 @@
 			}
 		},
 		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.201.1.tgz",
-			"integrity": "sha512-+q/8Yuhtu9QxCcjEAXEO8fXLjlSnrnVwfzi9jiWaMAppQp69MoagHHomQj02V2WnGjvBod5ajgkbK4IoWab50A==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+			"integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.201.1",
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1",
-				"@opentelemetry/sdk-logs": "0.201.1",
-				"@opentelemetry/sdk-metrics": "2.0.1",
-				"@opentelemetry/sdk-trace-base": "2.0.1",
+				"@opentelemetry/api-logs": "0.208.0",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/sdk-logs": "0.208.0",
+				"@opentelemetry/sdk-metrics": "2.2.0",
+				"@opentelemetry/sdk-trace-base": "2.2.0",
 				"protobufjs": "^7.3.0"
 			},
 			"engines": {
@@ -919,13 +917,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
-			"integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -936,15 +934,15 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.201.1.tgz",
-			"integrity": "sha512-Ug8gtpssUNUnfpotB9ZhnSsPSGDu+7LngTMgKl31mmVJwLAKyl6jC8diZrMcGkSgBh0o5dbg9puvLyR25buZfw==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+			"integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.201.1",
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1"
+				"@opentelemetry/api-logs": "0.208.0",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -954,14 +952,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
-			"integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+			"integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -971,14 +969,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-			"integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -989,14 +987,14 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-web": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.1.tgz",
-			"integrity": "sha512-R4/i0rISvAujG4Zwk3s6ySyrWG+Db3SerZVM4jZ2lEzjrNylF7nRAy1hVvWe8gTbwIxX+6w6ZvZwdtl2C7UQHQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.2.0.tgz",
+			"integrity": "sha512-x/LHsDBO3kfqaFx5qSzBljJ5QHsRXrvS4MybBDy1k7Svidb8ZyIPudWVzj3s5LpPkYZIgi9e+7tdsNCnptoelw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/sdk-trace-base": "2.0.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/sdk-trace-base": "2.2.0"
 			},
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -1006,9 +1004,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.34.0.tgz",
-			"integrity": "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
+			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1505,42 +1503,6 @@
 				"vite": "^6.3.0 || ^7.0.0"
 			}
 		},
-		"node_modules/@sveltejs/vite-plugin-svelte-inspector/node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1564,13 +1526,6 @@
 			"dependencies": {
 				"undici-types": "~7.10.0"
 			}
-		},
-		"node_modules/@types/shimmer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
@@ -2132,9 +2087,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2668,9 +2623,9 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
-			"integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.0.tgz",
+			"integrity": "sha512-yNZhyQYqXpkT0AKq3F3KLasUSK4fHvebNH5hOsKQw2dhGSALvQ4U0BqUc5suziKvydO5u5hgN2hy1RJaho8U5A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5868,9 +5823,9 @@
 			"dev": true
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-			"integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
@@ -6060,18 +6015,17 @@
 			}
 		},
 		"node_modules/require-in-the-middle": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.5",
-				"module-details-from-path": "^1.0.3",
-				"resolve": "^1.22.8"
+				"module-details-from-path": "^1.0.3"
 			},
 			"engines": {
-				"node": ">=8.6.0"
+				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
 			}
 		},
 		"node_modules/resolve": {
@@ -6255,13 +6209,6 @@
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
 			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
 			"dev": true
-		},
-		"node_modules/shimmer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-			"dev": true,
-			"license": "BSD-2-Clause"
 		},
 		"node_modules/sirv": {
 			"version": "3.0.1",
@@ -6825,9 +6772,9 @@
 			}
 		},
 		"node_modules/web-vitals": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.3.tgz",
-			"integrity": "sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+			"integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -7111,40 +7058,40 @@
 			"optional": true
 		},
 		"@grafana/faro-core": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.18.2.tgz",
-			"integrity": "sha512-+yHUfxvVgEkd3WnhEKQMWAyZ+qB2fvtCqbmngcU+VpCVufWhT480eqc46Gpz5GdhupLNPQu+FLhjyD4baX/owQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.0.2.tgz",
+			"integrity": "sha512-dUcQBUDzvWmDbVDlYYEmVyjxZJjqC8syCuE/YWDJp/Zps9DkDH5CdF5kWuSb3cCm6U1iTo9czDkORPj0KEN9WQ==",
 			"dev": true,
 			"requires": {
 				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/otlp-transformer": "^0.201.0"
+				"@opentelemetry/otlp-transformer": "^0.208.0"
 			}
 		},
 		"@grafana/faro-web-sdk": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.18.2.tgz",
-			"integrity": "sha512-tQYMJ1iOF2MTCACB05cUk3E0bP6Uj0zmSvfWyyArjQfyMWs/TW++cKhxGFKDOn7t/bj1sTvk3QqP0b7ecL5qrw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.0.2.tgz",
+			"integrity": "sha512-Tn5XUBfmEOXexFGRVmtR1JqyoUWU0luw1T27p9vwBCAg6X5yCVOf7N73ctIZ+WD7eS1DCLdAGT8ehx44WXgyeQ==",
 			"dev": true,
 			"requires": {
-				"@grafana/faro-core": "^1.18.2",
+				"@grafana/faro-core": "^2.0.2",
 				"ua-parser-js": "^1.0.32",
-				"web-vitals": "^4.0.1"
+				"web-vitals": "^5.0.3"
 			}
 		},
 		"@grafana/faro-web-tracing": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-1.18.2.tgz",
-			"integrity": "sha512-RqvixKN31RLXEo34ewDE2wQru3DMeQkYf4mh3SkQkFXtO8QToTHbOip8F0um0bO97+cJF9F8ArC5B3pg9KV9zA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-2.0.2.tgz",
+			"integrity": "sha512-jFKpXkAGI4SO1wlDQfZ6I0ZBeGq1VykT4TiGWFY7VnMnQZeiEUA/KfpJpEya+CdkDmd+c9hiBmSZDLzplu8dNA==",
 			"dev": true,
 			"requires": {
-				"@grafana/faro-web-sdk": "^1.18.2",
+				"@grafana/faro-web-sdk": "^2.0.2",
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/core": "^2.0.0",
-				"@opentelemetry/exporter-trace-otlp-http": "^0.201.0",
-				"@opentelemetry/instrumentation": "^0.201.0",
-				"@opentelemetry/instrumentation-fetch": "^0.201.0",
-				"@opentelemetry/instrumentation-xml-http-request": "^0.201.0",
-				"@opentelemetry/otlp-transformer": "^0.201.0",
+				"@opentelemetry/exporter-trace-otlp-http": "^0.208.0",
+				"@opentelemetry/instrumentation": "^0.208.0",
+				"@opentelemetry/instrumentation-fetch": "^0.208.0",
+				"@opentelemetry/instrumentation-xml-http-request": "^0.208.0",
+				"@opentelemetry/otlp-transformer": "^0.208.0",
 				"@opentelemetry/resources": "^2.0.0",
 				"@opentelemetry/sdk-trace-web": "^2.0.0",
 				"@opentelemetry/semantic-conventions": "^1.32.0"
@@ -7225,154 +7172,152 @@
 			"dev": true
 		},
 		"@opentelemetry/api-logs": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.201.1.tgz",
-			"integrity": "sha512-IxcFDP1IGMDemVFG2by/AMK+/o6EuBQ8idUq3xZ6MxgQGeumYZuX5OwR0h9HuvcUc/JPjQGfU5OHKIKYDJcXeA==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
 			"dev": true,
 			"requires": {
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"@opentelemetry/core": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-			"integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
 			"dev": true,
 			"requires": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			}
 		},
 		"@opentelemetry/exporter-trace-otlp-http": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.201.1.tgz",
-			"integrity": "sha512-Nw3pIqATC/9LfSGrMiQeeMQ7/z7W2D0wKPxtXwAcr7P64JW7KSH4YSX7Ji8Ti3MmB79NQg6imdagfegJDB0rng==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.208.0.tgz",
+			"integrity": "sha512-jbzDw1q+BkwKFq9yxhjAJ9rjKldbt5AgIy1gmEIJjEV/WRxQ3B6HcLVkwbjJ3RcMif86BDNKR846KJ0tY0aOJA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/otlp-exporter-base": "0.201.1",
-				"@opentelemetry/otlp-transformer": "0.201.1",
-				"@opentelemetry/resources": "2.0.1",
-				"@opentelemetry/sdk-trace-base": "2.0.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/otlp-exporter-base": "0.208.0",
+				"@opentelemetry/otlp-transformer": "0.208.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/sdk-trace-base": "2.2.0"
 			}
 		},
 		"@opentelemetry/instrumentation": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.201.1.tgz",
-			"integrity": "sha512-6EOSoT2zcyBM3VryAzn35ytjRrOMeaWZyzQ/PHVfxoXp5rMf7UUgVToqxOhQffKOHtC7Dma4bHt+DuwIBBZyZA==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
+			"integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-logs": "0.201.1",
-				"@types/shimmer": "^1.2.0",
-				"import-in-the-middle": "^1.8.1",
-				"require-in-the-middle": "^7.1.1",
-				"shimmer": "^1.2.1"
+				"@opentelemetry/api-logs": "0.208.0",
+				"import-in-the-middle": "^2.0.0",
+				"require-in-the-middle": "^8.0.0"
 			}
 		},
 		"@opentelemetry/instrumentation-fetch": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.201.1.tgz",
-			"integrity": "sha512-ZZZyQP+OYpMTK/Dm7j8W28GBLbtfe5r7rj+dAuhCQ5ELShJ4TUM0Ykcj2Oq4++2APeOzy8L6KkCukwtERdxzyQ==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.208.0.tgz",
+			"integrity": "sha512-zgStoUfNF1xH9bCq539k1aeieKxPiAvBo5gKipQ9fIt+eJsFvqGcSzrrDX+OYgpIPW/IVNgWBoOw6zVmKwgNwQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/instrumentation": "0.201.1",
-				"@opentelemetry/sdk-trace-web": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/instrumentation": "0.208.0",
+				"@opentelemetry/sdk-trace-web": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			}
 		},
 		"@opentelemetry/instrumentation-xml-http-request": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.201.1.tgz",
-			"integrity": "sha512-jh6KmoflVJo0SGK4fZupIbhIdw8lzfgiMLwUEetVMCJTkUStcZ1asWoZwV4r/SINnNE1oQntm+3LnO1jnUq6uw==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.208.0.tgz",
+			"integrity": "sha512-me0knebxJxnzis73p5/ZQgdLNG6nsUXMsDR/dZk+BPOiNyd3Me9ye2wVM06JlcLA54w4JESw6wMTNi4lMhowFQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/instrumentation": "0.201.1",
-				"@opentelemetry/sdk-trace-web": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/instrumentation": "0.208.0",
+				"@opentelemetry/sdk-trace-web": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			}
 		},
 		"@opentelemetry/otlp-exporter-base": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.201.1.tgz",
-			"integrity": "sha512-FiS/mIWmZXyRxYGyXPHY+I/4+XrYVTD7Fz/zwOHkVPQsA1JTakAOP9fAi6trXMio0dIpzvQujLNiBqGM7ExrQw==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+			"integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/otlp-transformer": "0.201.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/otlp-transformer": "0.208.0"
 			}
 		},
 		"@opentelemetry/otlp-transformer": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.201.1.tgz",
-			"integrity": "sha512-+q/8Yuhtu9QxCcjEAXEO8fXLjlSnrnVwfzi9jiWaMAppQp69MoagHHomQj02V2WnGjvBod5ajgkbK4IoWab50A==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+			"integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-logs": "0.201.1",
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1",
-				"@opentelemetry/sdk-logs": "0.201.1",
-				"@opentelemetry/sdk-metrics": "2.0.1",
-				"@opentelemetry/sdk-trace-base": "2.0.1",
+				"@opentelemetry/api-logs": "0.208.0",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/sdk-logs": "0.208.0",
+				"@opentelemetry/sdk-metrics": "2.2.0",
+				"@opentelemetry/sdk-trace-base": "2.2.0",
 				"protobufjs": "^7.3.0"
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
-			"integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			}
 		},
 		"@opentelemetry/sdk-logs": {
-			"version": "0.201.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.201.1.tgz",
-			"integrity": "sha512-Ug8gtpssUNUnfpotB9ZhnSsPSGDu+7LngTMgKl31mmVJwLAKyl6jC8diZrMcGkSgBh0o5dbg9puvLyR25buZfw==",
+			"version": "0.208.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+			"integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-logs": "0.201.1",
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1"
+				"@opentelemetry/api-logs": "0.208.0",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0"
 			}
 		},
 		"@opentelemetry/sdk-metrics": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.1.tgz",
-			"integrity": "sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+			"integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0"
 			}
 		},
 		"@opentelemetry/sdk-trace-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
-			"integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/resources": "2.0.1",
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			}
 		},
 		"@opentelemetry/sdk-trace-web": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.0.1.tgz",
-			"integrity": "sha512-R4/i0rISvAujG4Zwk3s6ySyrWG+Db3SerZVM4jZ2lEzjrNylF7nRAy1hVvWe8gTbwIxX+6w6ZvZwdtl2C7UQHQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.2.0.tgz",
+			"integrity": "sha512-x/LHsDBO3kfqaFx5qSzBljJ5QHsRXrvS4MybBDy1k7Svidb8ZyIPudWVzj3s5LpPkYZIgi9e+7tdsNCnptoelw==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "2.0.1",
-				"@opentelemetry/sdk-trace-base": "2.0.1"
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/sdk-trace-base": "2.2.0"
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.34.0.tgz",
-			"integrity": "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
+			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
 			"dev": true
 		},
 		"@polka/url": {
@@ -7651,17 +7596,6 @@
 				"deepmerge": "^4.3.1",
 				"magic-string": "^0.30.17",
 				"vitefu": "^1.1.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.4.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-					"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.3"
-					}
-				}
 			}
 		},
 		"@sveltejs/vite-plugin-svelte-inspector": {
@@ -7671,17 +7605,6 @@
 			"dev": true,
 			"requires": {
 				"debug": "^4.4.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.4.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-					"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.3"
-					}
-				}
 			}
 		},
 		"@types/cookie": {
@@ -7704,12 +7627,6 @@
 			"requires": {
 				"undici-types": "~7.10.0"
 			}
-		},
-		"@types/shimmer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-			"dev": true
 		},
 		"acorn": {
 			"version": "8.15.0",
@@ -8095,9 +8012,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"dev": true,
 			"requires": {
 				"ms": "^2.1.3"
@@ -8485,9 +8402,9 @@
 			}
 		},
 		"import-in-the-middle": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
-			"integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.0.tgz",
+			"integrity": "sha512-yNZhyQYqXpkT0AKq3F3KLasUSK4fHvebNH5hOsKQw2dhGSALvQ4U0BqUc5suziKvydO5u5hgN2hy1RJaho8U5A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.14.0",
@@ -10564,9 +10481,9 @@
 			"dev": true
 		},
 		"protobufjs": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-			"integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
 			"dev": true,
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -10699,14 +10616,13 @@
 			}
 		},
 		"require-in-the-middle": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.3.5",
-				"module-details-from-path": "^1.0.3",
-				"resolve": "^1.22.8"
+				"module-details-from-path": "^1.0.3"
 			}
 		},
 		"resolve": {
@@ -10825,12 +10741,6 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
 			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-			"dev": true
-		},
-		"shimmer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
 			"dev": true
 		},
 		"sirv": {
@@ -11165,9 +11075,9 @@
 			"requires": {}
 		},
 		"web-vitals": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.3.tgz",
-			"integrity": "sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+			"integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
 			"dev": true
 		},
 		"wrappy": {

--- a/pkg/web/package.json
+++ b/pkg/web/package.json
@@ -13,8 +13,8 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.4",
-		"@grafana/faro-web-sdk": "1.18.2",
-		"@grafana/faro-web-tracing": "1.18.2",
+		"@grafana/faro-web-sdk": "2.0.2",
+		"@grafana/faro-web-tracing": "2.0.2",
 		"@sveltejs/adapter-auto": "6.1.0",
 		"@sveltejs/adapter-static": "3.0.9",
 		"@sveltejs/kit": "2.37.0",


### PR DESCRIPTION
Faro v2.0.x has recently been released, which introduces some new features.

This PR bumps the Faro version used.

Have also followed the [Breaking Changes for v2](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/upgrading/upgrade-v2/), and found nothing to be changed as a result.