### PR TITLE
Add Faro User Actions Instrumentation

### DIFF
--- a/pkg/web/src/routes/+page.svelte
+++ b/pkg/web/src/routes/+page.svelte
@@ -112,6 +112,11 @@ async function ratePizza(stars) {
 		pizza_id: pizza['pizza']['id'],
 		stars: stars,
 	});
+	faro.api.startUserAction(
+		'ratePizza', // name of the user action
+		{ pizza_id: pizza['pizza']['id'], stars: stars }, // custom attributes attached to the user action
+		{ triggerName: 'ratePizzaButtonClick' }, // custom config
+	);
 	const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/ratings`, {
 		method: 'POST',
 		body: JSON.stringify({
@@ -134,6 +139,11 @@ async function getPizza() {
 	faro.api.pushEvent('Get Pizza Recommendation', {
 		restrictions: restrictions,
 	});
+	faro.api.startUserAction(
+		'getPizza', // name of the user action
+		{ restrictions: restrictions }, // custom attributes attached to the user action
+		{ triggerName: 'getPizzaButtonClick' }, // custom config
+	);
 	if (restrictions.minNumberOfToppings > restrictions.maxNumberOfToppings) {
 		faro.api.pushError(new Error('Invalid Restrictions, Min > Max'));
 	}

--- a/pkg/web/src/routes/admin/+page.svelte
+++ b/pkg/web/src/routes/admin/+page.svelte
@@ -26,6 +26,11 @@ function checkAdminLoggedIn() {
 }
 
 async function handleSubmit() {
+	faro.api.startUserAction(
+		'adminLogin', // name of the user action
+		{ username: username }, // custom attributes attached to the user action
+		{ triggerName: 'adminLoginButtonClick', importance: 'critical' }, // custom config
+	);
 	const res = await fetch(
 		`${PUBLIC_BACKEND_ENDPOINT}/api/admin/login?user=${username}&password=${password}`,
 		{
@@ -45,6 +50,11 @@ async function handleSubmit() {
 }
 
 async function handleLogout() {
+	faro.api.startUserAction(
+		'adminLogout', // name of the user action
+		{ username: username }, // custom attributes attached to the user action
+		{ triggerName: 'adminLogoutButtonClick', importance: 'critical' }, // custom config
+	);
 	faro.api.pushEvent('Admin Logout');
 	// Perhaps surprisingly, this only deletes (clears the value of) the admin_token cookie.
 	document.cookie = 'admin_token=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';

--- a/pkg/web/src/routes/login/+page.svelte
+++ b/pkg/web/src/routes/login/+page.svelte
@@ -43,6 +43,11 @@ async function fetchCSRFToken() {
 }
 
 async function handleSubmit() {
+	faro.api.startUserAction(
+		'userLogin', // name of the user action
+		{ username: username }, // custom attributes attached to the user action
+		{ triggerName: 'userLoginButtonClick', importance: 'critical' }, // custom config
+	);
 	const res = await fetch(
 		`${PUBLIC_BACKEND_ENDPOINT}/api/users/token/login?set_cookie=true`,
 		{
@@ -95,6 +100,11 @@ async function updateRatings() {
 }
 
 async function deleteRatings() {
+	faro.api.startUserAction(
+		'userDeleteRatings', // name of the user action
+		{ username: username }, // custom attributes attached to the user action
+		{ triggerName: 'userDeleteRatingsButtonClick', importance: 'critical' }, // custom config
+	);
 	const res = await fetch(`${PUBLIC_BACKEND_ENDPOINT}/api/ratings`, {
 		method: 'DELETE',
 		credentials: 'same-origin',
@@ -118,6 +128,11 @@ async function deleteRatings() {
 }
 
 async function handleLogout() {
+	faro.api.startUserAction(
+		'userLogout', // name of the user action
+		{ username: username }, // custom attributes attached to the user action
+		{ triggerName: 'userLogoutButtonClick', importance: 'critical' }, // custom config
+	);
 	faro.api.pushEvent('User Logout');
 	document.cookie = 'qp_user_token=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
 	qpUserLoggedIn = false;


### PR DESCRIPTION
This PR adds some example of the new User Actions feature in Faro v2, for various Button Click Events;

- **Add Example of Faro User Actions to Main Page**
- **Add Example of Faro User Actions to Admin Page**
- **Add Example of Faro User Actions to Login Page**

For the Admin and Login page the Login and Logout Buttons are marked as "Critical" Importance, all other User Actions are "Normal" Importance.

An example of this in Frontend Observability is;

<img width="1578" height="889" alt="image" src="https://github.com/user-attachments/assets/d9989930-f94b-4fa1-8ada-85b21f830fac" />

(The `adminUpdateReccomendations` User Actions were removed, as they were not needed, but still remain in that screenshot from earlier testing)