### PR TITLE
switch recommendation logging back to info level

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1490,7 +1490,7 @@ func (s *Server) AddRecommendations(catalogClient CatalogClient, copyClient Copy
 			pizzaCaloriesPerSlice.Observe(float64(pizzaRecommendation.Calories))
 			pizzaCaloriesPerSliceNativeHistogram.Observe(float64(pizzaRecommendation.Calories))
 
-			s.log.DebugContext(r.Context(), "New pizza recommendation", "pizza", pizzaRecommendation.Pizza.Name)
+			s.log.InfoContext(r.Context(), "New pizza recommendation", "pizza", pizzaRecommendation.Pizza.Name)
 			s.writeJSONResponse(w, r, pizzaRecommendation, http.StatusOK)
 		})
 	})


### PR DESCRIPTION
This reverts part of https://github.com/grafana/quickpizza/commit/36e0374fcdb78e63250c8ef52f9e18ecce6c338e to re-enable info logging for the pizza recommendation log line.

This log line is useful for demoing application logging, especially for demo-dashboards