### PR TITLE
Followup DB o11y config

### DIFF
--- a/alloy/cloud.alloy
+++ b/alloy/cloud.alloy
@@ -281,7 +281,7 @@ database_observability.postgres "postgres_quickpizza" {
   data_source_name  = coalesce(env("QUICKPIZZA_DB"), "postgresql://localhost:5432/notexist")
   forward_to        = [loki.relabel.database_observability_postgres_quickpizza.receiver]
   targets           = prometheus.exporter.postgres.postgres_quickpizza.targets
-  enable_collectors = ["query_details", "query_samples", "schema_details"]
+  enable_collectors = ["query_details", "query_samples", "schema_details", "explain_plans"]
 }
 
 loki.relabel "database_observability_postgres_quickpizza" {
@@ -291,7 +291,10 @@ loki.relabel "database_observability_postgres_quickpizza" {
     target_label = "job"
     replacement  = "integrations/db-o11y"
   }
-
+  rule {
+    target_label = "instance"
+    replacement = "postgres-quickpizza"
+  }
   rule {
     target_label = "service_namespace"
     replacement = env("SERVICE_NAMESPACE")
@@ -317,7 +320,10 @@ discovery.relabel "database_observability_postgres_quickpizza" {
     target_label = "job"
     replacement  = "integrations/db-o11y"
   }
-
+  rule {
+    target_label = "instance"
+    replacement = "postgres-quickpizza"
+  }
   rule {
     target_label = "service_namespace"
     replacement = env("SERVICE_NAMESPACE")

--- a/compose.grafana-cloud.microservices.yaml
+++ b/compose.grafana-cloud.microservices.yaml
@@ -23,7 +23,7 @@ services:
       - run
       - /config.alloy
       - --server.http.listen-addr=0.0.0.0:12345
-      - --stability.level=experimental
+      - --stability.level=public-preview
     ports:
       - "12345:12345"
       - "4317:4317" # OTLP gRPC

--- a/compose.grafana-cloud.monolithic.yaml
+++ b/compose.grafana-cloud.monolithic.yaml
@@ -11,7 +11,7 @@ services:
       - run
       - /config.alloy
       - --server.http.listen-addr=0.0.0.0:12345
-      - --stability.level=experimental
+      - --stability.level=public-preview
     ports:
       - "12345:12345"
       - "4317:4317" # OTLP gRPC

--- a/scripts/init-db-observability.sh
+++ b/scripts/init-db-observability.sh
@@ -60,6 +60,9 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "postgres" <<-EOSQL
 
     -- Grant object privileges for detailed data
     GRANT pg_read_all_data TO "$DB_O11Y_USER";
+
+    -- Disable pg_stat_statements tracking for this user
+    ALTER ROLE "$DB_O11Y_USER" SET pg_stat_statements.track = 'none';
 EOSQL
 
 echo "✓ User $DB_O11Y_USER created with base privileges"

--- a/terraform/alloy.tf
+++ b/terraform/alloy.tf
@@ -91,7 +91,7 @@ resource "kubernetes_deployment" "alloy" {
           args = [
             "run",
             "/conf/config.alloy",
-            "--stability.level=experimental"
+            "--stability.level=public-preview"
           ]
           env_from {
             secret_ref {

--- a/terraform/alloy/config.alloy
+++ b/terraform/alloy/config.alloy
@@ -357,7 +357,7 @@ database_observability.postgres "postgres_quickpizza" {
   data_source_name  = env("QUICKPIZZA_DB")
   forward_to        = [loki.relabel.database_observability_postgres_quickpizza.receiver]
   targets           = prometheus.exporter.postgres.postgres_quickpizza.targets
-  enable_collectors = ["query_details", "query_samples", "schema_details"]
+  enable_collectors = ["query_details", "query_samples", "schema_details", "explain_plans"]
 }
 
 loki.relabel "database_observability_postgres_quickpizza" {
@@ -367,7 +367,10 @@ loki.relabel "database_observability_postgres_quickpizza" {
     target_label = "job"
     replacement  = "integrations/db-o11y"
   }
-
+  rule {
+    target_label = "instance"
+    replacement = "postgres-quickpizza"
+  }
   rule {
     target_label = "service_namespace"
     replacement = env("DB_SERVICE_NAMESPACE")
@@ -393,7 +396,10 @@ discovery.relabel "database_observability_postgres_quickpizza" {
     target_label = "job"
     replacement  = "integrations/db-o11y"
   }
-
+  rule {
+    target_label = "instance"
+    replacement = "postgres-quickpizza"
+  }
   rule {
     target_label = "service_namespace"
     replacement = env("DB_SERVICE_NAMESPACE")


### PR DESCRIPTION
Minor updates to the DB o11y config:
- Alloy component is `public-preview` since 1.12.0
- Add explicit `explain_plans` collector
- Add `instance` relabeling for nicer visualization
- Disable self-tracking for `db-o11y` database user