### PR TITLE
Add new httpRequestDurationNativeHistogram metric and rename existing native histogram metrics.

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -56,11 +56,11 @@ These are custom application metrics specific to the QuickPizza application, imp
 
 - `quickpizza_server_number_of_ingredients_per_pizza`: Distribution of ingredients per pizza (Classic Histogram).
 
-- `quickpizza_server_number_of_ingredients_per_pizza_alternate`: Distribution of ingredients per pizza (Native Histogram).
+- `quickpizza_server_number_of_ingredients_per_pizza_native`: Distribution of ingredients per pizza (Native Histogram).
 
 - `quickpizza_server_pizza_calories_per_slice`: Distribution of calories per pizza slice (Classic Histogram).
 
-- `quickpizza_server_pizza_calories_per_slice_alternate`: Distribution of calories per pizza slice (Native Histogram).
+- `quickpizza_server_pizza_calories_per_slice_native`: Distribution of calories per pizza slice (Native Histogram).
 
 - `quickpizza_server_http_requests_total`: Total number of HTTP requests received (Counter metric).
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -62,6 +62,8 @@ These are custom application metrics specific to the QuickPizza application, imp
 
 - `quickpizza_server_pizza_calories_per_slice_native`: Distribution of calories per pizza slice (Native Histogram).
 
-- `quickpizza_server_http_requests_total`: Total number of HTTP requests received (Counter metric).
-
 - `quickpizza_server_http_request_duration_seconds`: Duration of HTTP request processing (Classic Histogram).
+
+- `quickpizza_server_http_request_duration_seconds_native`: Duration of HTTP request processing (Native Histogram).
+
+- `quickpizza_server_http_requests_total`: Total number of HTTP requests received (Counter metric).

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -105,6 +105,16 @@ var (
 		Name:      "http_request_duration_seconds",
 		Help:      "The duration of HTTP requests",
 	}, []string{"method", "path", "status"})
+
+	httpRequestDurationNativeHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       "quickpizza",
+		Subsystem:                       "server",
+		Name:                            "http_request_duration_seconds_native",
+		Help:                            "The duration of HTTP requests (Native Histogram)",
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	}, []string{"method", "path", "status"})
 )
 
 // PizzaRecommendation is the object returned by the /api/pizza endpoint.
@@ -1568,5 +1578,6 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 
 		httpRequests.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Inc()
 		httpRequestDuration.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Observe(duration.Seconds())
+		httpRequestDurationNativeHistogram.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Observe(duration.Seconds())
 	})
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -67,7 +67,7 @@ var (
 	numberOfIngredientsPerPizzaNativeHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace:                       "quickpizza",
 		Subsystem:                       "server",
-		Name:                            "number_of_ingredients_per_pizza_alternate",
+		Name:                            "number_of_ingredients_per_pizza_native",
 		Help:                            "The number of ingredients per pizza (Native Histogram)",
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
@@ -85,7 +85,7 @@ var (
 	pizzaCaloriesPerSliceNativeHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace:                       "quickpizza",
 		Subsystem:                       "server",
-		Name:                            "pizza_calories_per_slice_alternate",
+		Name:                            "pizza_calories_per_slice_native",
 		Help:                            "The number of calories per slice of pizza (Native Histogram)",
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,


### PR DESCRIPTION

- Use `_native` suffix for native histogram metrics instead of `_alternate`
- Add a native histogram version of the HTTP request duration metric (`quickpizza_server_http_request_duration_seconds_native`) following the same pattern used for other native histogram metrics.