### PR TITLE
feat: add http_request_duration_seconds_gauge metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -66,4 +66,6 @@ These are custom application metrics specific to the QuickPizza application, imp
 
 - `quickpizza_server_http_request_duration_seconds_native`: Duration of HTTP request processing (Native Histogram).
 
+- `quickpizza_server_http_request_duration_seconds_gauge`: Duration of HTTP request processing (Gauge).
+
 - `quickpizza_server_http_requests_total`: Total number of HTTP requests received (Counter metric).

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -115,6 +115,13 @@ var (
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	}, []string{"method", "path", "status"})
+
+	httpRequestDurationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "quickpizza",
+		Subsystem: "server",
+		Name:      "http_request_duration_seconds_gauge",
+		Help:      "The duration of HTTP requests (Gauge)",
+	}, []string{"method", "path", "status"})
 )
 
 // PizzaRecommendation is the object returned by the /api/pizza endpoint.
@@ -1573,5 +1580,6 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 		httpRequests.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Inc()
 		httpRequestDuration.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Observe(duration.Seconds())
 		httpRequestDurationNativeHistogram.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Observe(duration.Seconds())
+		httpRequestDurationGauge.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Set(duration.Seconds())
 	})
 }


### PR DESCRIPTION
Add a Prometheus Gauge metric to track HTTP request duration alongside the existing histogram metrics. 

This provides an alternative way to monitor request latency using a gauge metric.
