### PR TITLE
feat: add WebSocket-specific Prometheus metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,3 +69,17 @@ These are custom application metrics specific to the QuickPizza application, imp
 - `quickpizza_server_http_request_duration_seconds_gauge`: Duration of HTTP request processing (Gauge).
 
 - `quickpizza_server_http_requests_total`: Total number of HTTP requests received (Counter metric).
+
+## QuickPizza WebSocket Metrics
+
+`quickpizza_server_ws_*`
+
+These metrics track WebSocket connection lifecycle and message processing. They are separate from HTTP metrics because WebSocket connections are long-lived and would skew HTTP latency results.
+
+- `quickpizza_server_ws_connections_active`: Number of currently active WebSocket connections (Gauge).
+
+- `quickpizza_server_ws_connection_duration_seconds`: Duration of WebSocket connections in seconds (Native Histogram).
+
+- `quickpizza_server_ws_messages_received_total`: Total number of messages received via WebSocket (Counter).
+
+- `quickpizza_server_ws_message_processing_duration_seconds`: Time to process and broadcast incoming WebSocket messages (Native Histogram).


### PR DESCRIPTION

WebSocket connections were skewing HTTP latency metrics because their connection duration was being recorded as request duration.

 This PR:

- Excludes `/ws` from Prometheus HTTP metrics (`isInternalRoute`)
- Excludes `/ws` from OTel tracing and metrics (`excludeWebSocketFromOTel`)
- Adds 4 dedicated WebSocket metrics via melody hooks:
  - `quickpizza_server_ws_connections_active` (Gauge)
  - `quickpizza_server_ws_connection_duration_seconds` (Native Histogram)
  - `quickpizza_server_ws_messages_received_total` (Counter)
  - `quickpizza_server_ws_message_processing_duration_seconds` (Native Histogram)
