### PR TITLE
Fix #287 Configure Trace to metrics/profiles/logs for OSS

### DIFF
--- a/deployments/docker-compose/grafana-local-stack/grafana/datasources/datasource.yaml
+++ b/deployments/docker-compose/grafana-local-stack/grafana/datasources/datasource.yaml
@@ -53,10 +53,12 @@ datasources:
       # https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/#trace-to-profiles
       tracesToProfiles:
         datasourceUid: "pyroscope"
-        # tags:
-        #   - key: "service.name"
-        #     value: "service_name"
-        # profileTypeId: "process_cpu:cpu:nanoseconds:cpu:nanoseconds" # default profile type
+        tags:
+          - key: "service.name"
+            value: "service_name"
+          - key: "service.namespace"
+            value: "service_namespace"
+        profileTypeId: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
   - name: Pyroscope
     type: "phlare"
     uid: pyroscope

--- a/deployments/docker-compose/grafana-local-stack/grafana/datasources/datasource.yaml
+++ b/deployments/docker-compose/grafana-local-stack/grafana/datasources/datasource.yaml
@@ -41,6 +41,22 @@ datasources:
         datasourceUid: "prometheus"
       nodeGraph:
         enabled: true
+      # traces to metrics configuration
+      #https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/#trace-to-metrics
+      tracesToMetrics:
+        datasourceUid: "prometheus"
+      # traces to logs configuration
+      # https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/#trace-to-logs
+      tracesToLogs:
+        datasourceUid: "loki"
+      # traces to profiles configuration
+      # https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/#trace-to-profiles
+      tracesToProfiles:
+        datasourceUid: "pyroscope"
+        # tags:
+        #   - key: "service.name"
+        #     value: "service_name"
+        # profileTypeId: "process_cpu:cpu:nanoseconds:cpu:nanoseconds" # default profile type
   - name: Pyroscope
     type: "phlare"
     uid: pyroscope
@@ -51,6 +67,7 @@ datasources:
     editable: false
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     orgId: 1
     url: http://loki:3100


### PR DESCRIPTION
**Checklist:**
- [x] Add traces to metrics link in datasources
- [x] Add traces to logs link in datasources
- [x] Add traces to profiles link in datasources
- [ ] Make it so that I actually get metrics from traces
- [x] Make it so that I actually get logs from traces
- [x] Make it so that I actually get profiles from traces

<img width="630" height="1046" alt="image" src="https://github.com/user-attachments/assets/5f168ba7-5e4a-4aeb-9940-599c29d96270" /><p>


Traces to logs
<img width="1985" height="979" alt="image" src="https://github.com/user-attachments/assets/206e9cfb-6686-44fd-aaf5-82a38f766b02" /><p>

Traces to profiles
<img width="1997" height="1110" alt="image" src="https://github.com/user-attachments/assets/5755f188-c075-4b67-af20-f28e239b3e16" />


**Future iteration:**
- [ ] Get `Open in Profiles Drilldown` button to work in Cloud and OSS

Also, checking with Marie since in learn.grafana traces to metrics is not enabled in datasources, so need to check if Play has traces to metrics in the datasources.