### PR TITLE
fix: safely call Faro via window optional chaining

### DIFF
--- a/pkg/web/src/routes/+page.svelte
+++ b/pkg/web/src/routes/+page.svelte
@@ -104,15 +104,15 @@ onMount(async () => {
 	});
 	getTools();
 	render = true;
-	faro.api.pushEvent('Navigation', { url: window.location.href });
+	window.faro?.api?.pushEvent('Navigation', { url: window.location.href });
 });
 
 async function ratePizza(stars) {
-	faro.api.pushEvent('Submit Pizza Rating', {
+	window.faro?.api?.pushEvent('Submit Pizza Rating', {
 		pizza_id: pizza['pizza']['id'],
 		stars: stars,
 	});
-	faro.api.startUserAction(
+	window.faro?.api?.startUserAction(
 		'ratePizza', // name of the user action
 		{ pizza_id: pizza['pizza']['id'], stars: stars }, // custom attributes attached to the user action
 		{ triggerName: 'ratePizzaButtonClick' }, // custom config
@@ -131,21 +131,23 @@ async function ratePizza(stars) {
 		rateResult = 'Rated!';
 	} else {
 		rateResult = 'Please log in first.';
-		faro.api.pushError(new Error('Unauthenticated Ratings Submission'));
+		window.faro?.api?.pushError(
+			new Error('Unauthenticated Ratings Submission'),
+		);
 	}
 }
 
 async function getPizza() {
-	faro.api.pushEvent('Get Pizza Recommendation', {
+	window.faro?.api?.pushEvent('Get Pizza Recommendation', {
 		restrictions: restrictions,
 	});
-	faro.api.startUserAction(
+	window.faro?.api?.startUserAction(
 		'getPizza', // name of the user action
 		{ restrictions: restrictions }, // custom attributes attached to the user action
 		{ triggerName: 'getPizzaButtonClick' }, // custom config
 	);
 	if (restrictions.minNumberOfToppings > restrictions.maxNumberOfToppings) {
-		faro.api.pushError(new Error('Invalid Restrictions, Min > Max'));
+		window.faro?.api?.pushError(new Error('Invalid Restrictions, Min > Max'));
 	}
 
 	// Build headers: use cookie auth if logged in, otherwise use anonymous token
@@ -170,7 +172,7 @@ async function getPizza() {
 		pizza = '';
 		errorResult =
 			json.error || 'Failed to get pizza recommendation. Please try again.';
-		faro.api.pushError(new Error(errorResult));
+		window.faro?.api?.pushError(new Error(errorResult));
 		return;
 	}
 
@@ -192,11 +194,13 @@ async function getPizza() {
 		};
 		socket.addEventListener('open', handleOpen);
 	} else {
-		faro.api.pushError(new Error('socket state error: ' + socket.readyState));
+		window.faro?.api?.pushError(
+			new Error('socket state error: ' + socket.readyState),
+		);
 	}
 
 	if (pizza['pizza']['ingredients'].find((e) => e.name === 'Pineapple')) {
-		faro.api.pushError(
+		window.faro?.api?.pushError(
 			new Error(
 				'Pizza Error: Pineapple detected! This is a violation of ancient pizza law. Proceed at your own risk!',
 			),
@@ -205,7 +209,7 @@ async function getPizza() {
 }
 
 async function getTools() {
-	faro.api.pushEvent('Get Pizza Tools', { tools: tools });
+	window.faro?.api?.pushEvent('Get Pizza Tools', { tools: tools });
 
 	// Build headers: use cookie auth if logged in, otherwise use anonymous token
 	const headers: Record<string, string> = {};

--- a/pkg/web/src/routes/admin/+page.svelte
+++ b/pkg/web/src/routes/admin/+page.svelte
@@ -26,7 +26,7 @@ function checkAdminLoggedIn() {
 }
 
 async function handleSubmit() {
-	faro.api.startUserAction(
+	window.faro?.api?.startUserAction(
 		'adminLogin', // name of the user action
 		{ username: username }, // custom attributes attached to the user action
 		{ triggerName: 'adminLoginButtonClick', importance: 'critical' }, // custom config
@@ -40,22 +40,26 @@ async function handleSubmit() {
 	);
 	if (!res.ok) {
 		loginError = 'Login failed: ' + res.statusText;
-		faro.api.pushEvent('Unsuccessful Admin Login', { username: username });
-		faro.api.pushError(new Error('Admin Login Error: ' + res.statusText));
+		window.faro?.api?.pushEvent('Unsuccessful Admin Login', {
+			username: username,
+		});
+		window.faro?.api?.pushError(
+			new Error('Admin Login Error: ' + res.statusText),
+		);
 		return;
 	}
 
-	faro.api.pushEvent('Successful Admin Login', { username: username });
+	window.faro?.api?.pushEvent('Successful Admin Login', { username: username });
 	adminLoggedIn = checkAdminLoggedIn();
 }
 
 async function handleLogout() {
-	faro.api.startUserAction(
+	window.faro?.api?.startUserAction(
 		'adminLogout', // name of the user action
 		{ username: username }, // custom attributes attached to the user action
 		{ triggerName: 'adminLogoutButtonClick', importance: 'critical' }, // custom config
 	);
-	faro.api.pushEvent('Admin Logout');
+	window.faro?.api?.pushEvent('Admin Logout');
 	// Perhaps surprisingly, this only deletes (clears the value of) the admin_token cookie.
 	document.cookie = 'admin_token=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
 	adminLoggedIn = false;
@@ -72,14 +76,14 @@ function updateRecommendations() {
 	})
 		.then((res) => res.json())
 		.then((json) => {
-			faro.api.pushEvent('Update Recent Pizza Recommendations');
+			window.faro?.api?.pushEvent('Update Recent Pizza Recommendations');
 			var newRec: string[] = [];
 			json.pizzas.forEach((pizza: string) => {
 				newRec.push(`
                 ${pizza.name} (tool=${pizza.tool}, ingredients_number=${pizza.ingredients.length})`);
 			});
 			if (newRec.length >= 15) {
-				faro.api.pushError(new Error('Too Many Recommendations'));
+				window.faro?.api?.pushError(new Error('Too Many Recommendations'));
 			}
 			newRec = newRec.slice(0, 15);
 			if (newRec.length >= 0) {

--- a/pkg/web/src/routes/login/+page.svelte
+++ b/pkg/web/src/routes/login/+page.svelte
@@ -36,7 +36,7 @@ async function fetchCSRFToken() {
 }
 
 async function handleSubmit() {
-	faro.api.startUserAction(
+	window.faro?.api?.startUserAction(
 		'userLogin', // name of the user action
 		{ username: username }, // custom attributes attached to the user action
 		{ triggerName: 'userLoginButtonClick', importance: 'critical' }, // custom config
@@ -58,12 +58,12 @@ async function handleSubmit() {
 	);
 	if (!res.ok) {
 		loginError = 'Login failed: ' + res.statusText;
-		faro.api.pushEvent('Unsuccessful Login', { username: username });
-		faro.api.pushError(new Error('Login Error: ' + res.statusText));
+		window.faro?.api?.pushEvent('Unsuccessful Login', { username: username });
+		window.faro?.api?.pushError(new Error('Login Error: ' + res.statusText));
 		return;
 	}
 
-	faro.api.pushEvent('Successful Login', { username: username });
+	window.faro?.api?.pushEvent('Successful Login', { username: username });
 	// After successful login, the cookie is set by the server, so we can trust it's valid
 	qpUserLoggedIn = hasUserTokenCookie();
 	isLoggedInStore.set(qpUserLoggedIn);
@@ -95,7 +95,7 @@ async function updateRatings() {
 }
 
 async function deleteRatings() {
-	faro.api.startUserAction(
+	window.faro?.api?.startUserAction(
 		'userDeleteRatings', // name of the user action
 		{ username: username }, // custom attributes attached to the user action
 		{ triggerName: 'userDeleteRatingsButtonClick', importance: 'critical' }, // custom config
@@ -123,12 +123,12 @@ async function deleteRatings() {
 }
 
 async function handleLogout() {
-	faro.api.startUserAction(
+	window.faro?.api?.startUserAction(
 		'userLogout', // name of the user action
 		{ username: username }, // custom attributes attached to the user action
 		{ triggerName: 'userLogoutButtonClick', importance: 'critical' }, // custom config
 	);
-	faro.api.pushEvent('User Logout');
+	window.faro?.api?.pushEvent('User Logout');
 	document.cookie = 'qp_user_token=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
 	qpUserLoggedIn = false;
 	isLoggedInStore.set(false);


### PR DESCRIPTION
If Faro fails to load, or JS logic runs before Faro has finished loading, `faro` and/or `faro.api` may be undefined, causing pages to not work as expected. This was seen in https://github.com/grafana/synthetic-monitoring-app/pull/1580, where test scripts were attempting to submit the login form before Faro was loaded, causing the JS to error and fail. I've switched all Faro usages from `faro.api.` to `window.faro?.api?.`, which should handle both `window.faro` being undefined (before Faro has loaded) and `window.faro.api` being defined (before Faro has initialized).