### PR TITLE
feat: attach trace_id exemplars to HTTP request duration histograms

### DIFF
--- a/deployments/docker-compose/grafana-local-stack/config.alloy
+++ b/deployments/docker-compose/grafana-local-stack/config.alloy
@@ -95,6 +95,7 @@ prometheus.remote_write "local" {
     // TODO: Replace this with your prometheus-compatible metrics store
     url = env("METRICS_ENDPOINT")
     send_native_histograms = true
+    send_exemplars = true
   }
 }
 prometheus.scrape "app_containers" {

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1642,12 +1642,22 @@ func excludeWebSocketFromOTel() otelhttp.Option {
 
 // HTTPMetricsMiddleware records Prometheus metrics for HTTP requests.
 // It captures request count, duration (histogram), and duration (gauge) with labels
-// for method, path (route pattern), and status code.
+// for method, path (route pattern), and status code. It also attaches exemplars
+// containing trace context to histogram metrics for observability linking.
+//
+// Exemplars rely on OTelRouteLabeler populating an exemplarData pointer stored
+// in the request context. This avoids installing otelhttp at the root level.
 func HTTPMetricsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-		next.ServeHTTP(ww, r)
+
+		// Store a mutable pointer in the context for OTelRouteLabeler to populate
+		// with trace IDs after otelhttp creates the span.
+		ed := &exemplarData{}
+		ctx := context.WithValue(r.Context(), exemplarKey, ed)
+
+		next.ServeHTTP(ww, r.WithContext(ctx))
 		duration := time.Since(start)
 
 		pattern := chi.RouteContext(r.Context()).RoutePattern()
@@ -1657,9 +1667,31 @@ func HTTPMetricsMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		httpRequests.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Inc()
-		httpRequestDuration.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Observe(duration.Seconds())
-		httpRequestDurationNativeHistogram.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Observe(duration.Seconds())
-		httpRequestDurationGauge.WithLabelValues(r.Method, pattern, strconv.Itoa(ww.Status())).Set(duration.Seconds())
+		statusStr := strconv.Itoa(ww.Status())
+		durationSeconds := duration.Seconds()
+
+		httpRequests.WithLabelValues(r.Method, pattern, statusStr).Inc()
+
+		// Record histogram observations with exemplars if trace context was populated
+		if ed.TraceID != "" {
+			labels := prometheus.Labels{
+				"trace_id": ed.TraceID,
+			}
+			if observer, ok := httpRequestDuration.WithLabelValues(r.Method, pattern, statusStr).(prometheus.ExemplarObserver); ok {
+				observer.ObserveWithExemplar(durationSeconds, labels)
+			} else {
+				httpRequestDuration.WithLabelValues(r.Method, pattern, statusStr).Observe(durationSeconds)
+			}
+			if observer, ok := httpRequestDurationNativeHistogram.WithLabelValues(r.Method, pattern, statusStr).(prometheus.ExemplarObserver); ok {
+				observer.ObserveWithExemplar(durationSeconds, labels)
+			} else {
+				httpRequestDurationNativeHistogram.WithLabelValues(r.Method, pattern, statusStr).Observe(durationSeconds)
+			}
+		} else {
+			httpRequestDuration.WithLabelValues(r.Method, pattern, statusStr).Observe(durationSeconds)
+			httpRequestDurationNativeHistogram.WithLabelValues(r.Method, pattern, statusStr).Observe(durationSeconds)
+		}
+
+		httpRequestDurationGauge.WithLabelValues(r.Method, pattern, statusStr).Set(durationSeconds)
 	})
 }

--- a/pkg/http/otel.go
+++ b/pkg/http/otel.go
@@ -42,9 +42,23 @@ func LogTraceID(next http.Handler) http.Handler {
 	})
 }
 
+// exemplarData holds trace context that inner middleware populates for outer middleware to read.
+// HTTPMetricsMiddleware stores a pointer in the context before calling next.ServeHTTP().
+// OTelRouteLabeler (running inside route groups, after otelhttp) writes the trace IDs into it.
+type exemplarData struct {
+	TraceID string
+}
+
+type exemplarKeyType int
+
+const exemplarKey exemplarKeyType = 0
+
 // OTelRouteLabeler is a middleware that adds the chi route pattern to OTel metrics.
 // This must be used AFTER otelhttp.NewHandler and will add an "http.route" label
 // to the http_server_request_duration_seconds metric.
+//
+// It also populates exemplarData (if present in the context) with the current
+// trace and span IDs, so that HTTPMetricsMiddleware can attach exemplars.
 //
 // Note: otelhttp.WithMetricAttributesFn cannot be used for this because the chi
 // route pattern is only resolved after routing, but WithMetricAttributesFn runs
@@ -58,6 +72,15 @@ func OTelRouteLabeler(next http.Handler) http.Handler {
 				}
 			}
 		}
+
+		// Populate exemplar data for HTTPMetricsMiddleware
+		if ed, ok := r.Context().Value(exemplarKey).(*exemplarData); ok {
+			spanCtx := trace.SpanFromContext(r.Context()).SpanContext()
+			if spanCtx.HasTraceID() {
+				ed.TraceID = spanCtx.TraceID().String()
+			}
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION

This PR attaches `trace_id` exemplars to `quickpizza_server_http_request_duration_seconds` and native histogram metrics, enabling metrics-to-traces linking in Grafana:


<img width="1400" height="855" alt="Screenshot 2026-03-02 at 21 18 49" src="https://github.com/user-attachments/assets/f789adc6-2122-4fba-b902-99e6e4917d18" />




Closes https://github.com/grafana/quickpizza/issues/297
