### PR TITLE
fix: reset seq db for ratings and users table

### DIFF
--- a/.github/workflows/build_and_test_no_docker.yaml
+++ b/.github/workflows/build_and_test_no_docker.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Setup k6
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1
+        with:
+          browser: true
 
       - name: Install jq
         uses: dcarbone/install-jq-action@e397bd87438d72198f81efd21f876461183d383a # v3.0.1
@@ -61,6 +63,16 @@ jobs:
 
       - name: Run k6 internal tests
         run: ./k6/run-tests.sh -t **/k6/internal/*.js -u http://localhost:3333
+
+      - name: Install Google Chrome (browser tests)
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y wget
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
 
       - name: Run k6 browser tests
         run: ./k6/run-tests.sh -t **/k6/browser/*.js -u http://localhost:3333

--- a/.github/workflows/example_browser_test.yaml
+++ b/.github/workflows/example_browser_test.yaml
@@ -5,6 +5,10 @@ jobs:
   basic_k6_test:
     name: k6 test run - browser test example
     runs-on: ubuntu-latest
+    env:
+      K6_BROWSER_EXECUTABLE_PATH: /usr/bin/google-chrome-stable
+      K6_BROWSER_ARGS: "no-sandbox,disable-dev-shm-usage,disable-features=PartitionAllocSchedulerLoopQuarantineTaskControlledPurge"
+      DBUS_SESSION_BUS_ADDRESS: /dev/null
 
     services:
       quickpizza:
@@ -15,6 +19,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Google Chrome
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y wget
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+
       - name: Setup k6
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1
         with:

--- a/.github/workflows/k6_browser_tests.yaml
+++ b/.github/workflows/k6_browser_tests.yaml
@@ -5,6 +5,14 @@ jobs:
   k6_browser_tests:
     name: k6 test run - running all browser tests
     runs-on: ubuntu-latest
+    env:
+      # Use system Chrome — bundled Chromium often SIGTRAP / D-Bus failures on GHA (xk6-browser e2e).
+      K6_BROWSER_EXECUTABLE_PATH: /usr/bin/google-chrome-stable
+      # Chrome 146+ on GHA: avoid crashpad on missing cpufreq sysfs (puppeteer#14742).
+      # k6 splits K6_BROWSER_ARGS on commas; value must be a single disable-features=… token.
+      K6_BROWSER_ARGS: "no-sandbox,disable-dev-shm-usage,disable-features=PartitionAllocSchedulerLoopQuarantineTaskControlledPurge"
+      # Avoid "Failed to connect to the bus" from Chromium on headless runners.
+      DBUS_SESSION_BUS_ADDRESS: /dev/null
 
     services:
       quickpizza:
@@ -15,6 +23,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Google Chrome
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y wget
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor --yes -o /usr/share/keyrings/google-chrome.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
 
       - name: Setup k6
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1

--- a/k6/run-tests.sh
+++ b/k6/run-tests.sh
@@ -15,9 +15,18 @@ TESTS="${TESTS:=**/k6/foundations/*.js}"
 LOGS=logs.txt
 
 export K6_BROWSER_HEADLESS=true
-export K6_BROWSER_ARGS='no-sandbox'
-if [ "$ACT" = "true" ]; then
-	export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
+# Chrome 146+: crashpad reads cpufreq sysfs that GitHub runners omit; disable the
+# triggering feature. Comma-separated K6_BROWSER_ARGS must not include commas
+# inside values, so we pass only this feature (replaces k6's default disable-features).
+# https://github.com/puppeteer/puppeteer/issues/14742
+export K6_BROWSER_ARGS='no-sandbox,disable-dev-shm-usage,disable-features=PartitionAllocSchedulerLoopQuarantineTaskControlledPurge'
+# Bundled Chromium can fail mid-run when many IterStart launches happen in parallel
+# (e.g. hybrid browser + HTTP scenarios). Prefer system Chrome on Linux CI; see
+# https://github.com/grafana/xk6-browser/blob/main/.github/workflows/e2e.yml
+if [ "$ACT" = "true" ] || { [ -n "${CI:-}" ] && [ "$(uname -s)" = "Linux" ]; }; then
+	export K6_BROWSER_EXECUTABLE_PATH="${K6_BROWSER_EXECUTABLE_PATH:-/usr/bin/google-chrome-stable}"
+	# Headless Linux runners: avoid Chromium D-Bus launch failures.
+	export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-/dev/null}"
 fi
 
 for test in $TESTS; do

--- a/pkg/database/migrations/catalog/20230830134500_seed_db.go
+++ b/pkg/database/migrations/catalog/20230830134500_seed_db.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"embed"
+	"fmt"
 
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dbfixture"
@@ -22,8 +23,21 @@ func init() {
 		// Reset PostgreSQL sequence after loading fixtures with explicit IDs
 		// SQLite handles autoincrement correctly without this
 		if _, ok := db.Dialect().(*pgdialect.Dialect); ok {
-			_, err := db.ExecContext(ctx, "SELECT setval('pizzas_id_seq', (SELECT MAX(id) FROM pizzas))")
-			return err
+			for _, reset := range []struct {
+				seq, table string
+			}{
+				{"pizzas_id_seq", "pizzas"},
+				{"users_id_seq", "users"},
+				{"ratings_id_seq", "ratings"},
+			} {
+				q := fmt.Sprintf(
+					"SELECT setval('%s', COALESCE((SELECT MAX(id) FROM %s), 1))",
+					reset.seq, reset.table,
+				)
+				if _, err := db.ExecContext(ctx, q); err != nil {
+					return err
+				}
+			}
 		}
 
 		return nil


### PR DESCRIPTION
Reset sequence for ratings and users table on seed db migration script to avoid errors when doing recommendations due to id constrains (id already exist). It's not possible to insert new values in ratings table because when you start docker and the seed script run, it's reseting just the pizzas table sequences.

This PR also contains some changes in Github workflows to fix checks