### PR TITLE
Replace removed --no-summary k6 flag with --summary-mode=none

### DIFF
--- a/k6/run-tests.sh
+++ b/k6/run-tests.sh
@@ -33,7 +33,7 @@ for test in $TESTS; do
 	# Disable thresholds because some threshold examples fail
     echo "Running: $test"
     rm -f $LOGS
-	$K6_PATH run --no-thresholds -e BASE_URL="$BASE_URL" --log-output=file=$LOGS --log-format=json -w --no-summary "$test"
+	$K6_PATH run --no-thresholds -e BASE_URL="$BASE_URL" --log-output=file=$LOGS --log-format=json -w --summary-mode=none "$test"
     k6_exit_code=$?
 
     # Only check error logs if logs file is not empty.


### PR DESCRIPTION
## Summary
- The `--no-summary` flag was removed in k6 v1.0.0
- Since `setup-k6-action@v1` installs the latest k6, CI fails with `unknown flag: --no-summary`
- Replaces it with the equivalent `--summary-mode=none`

## Test plan
- [ ] CI `runner-job` passes (currently broken on all PRs)