### PR TITLE
Add the QuickPizza demo dashhboards to the local docker setup

### DIFF
--- a/deployments/docker-compose/grafana-local-stack/grafana/dashboards/definitions/quickpizza_logs.json
+++ b/deployments/docker-compose/grafana-local-stack/grafana/dashboards/definitions/quickpizza_logs.json
@@ -1,0 +1,750 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": {
+					"type": "grafana",
+					"uid": "-- Grafana --"
+				},
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 0,
+	"liveNow": false,
+	"panels": [
+		{
+			"gridPos": {
+				"h": 3,
+				"w": 19,
+				"x": 0,
+				"y": 0
+			},
+			"id": 7,
+			"options": {
+				"code": {
+					"language": "plaintext",
+					"showLineNumbers": false,
+					"showMiniMap": false
+				},
+				"content": "<div style=\"padding: 3px;\">\n  <div style=\"margin-bottom: 3px;display: flex; flex-direction: row; align-items: center; margin-top: 3px;\">\n    <img style=\"height: 40px; width: 40px; margin-right: 10px;\" src=\"https://files.readme.io/e5e1b43-grafana-loki.png\" />\n    <h1 style=\"margin-top: 5px;\">QuickPizza Logs Demo Dashboard</h1>\n  </div>",
+				"mode": "html"
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [],
+			"title": "",
+			"transparent": true,
+			"type": "text"
+		},
+		{
+			"gridPos": {
+				"h": 4,
+				"w": 24,
+				"x": 0,
+				"y": 3
+			},
+			"id": 8,
+			"options": {
+				"code": {
+					"language": "plaintext",
+					"showLineNumbers": false,
+					"showMiniMap": false
+				},
+				"content": "---\n<div style=\"padding: 10px;\">\n\n### **Pre-configured Log Panels**\nThe panels below offer an introductory setup so you start observing Demo Logs. All of these panels are dynamic so you can view, share, share and inspect the data in each panel.\n\n---\n##### 💡 Tips\n- Hover over the ℹ️ icon to read a full description of what's included on each panel\n- Adjust the timepicker to select relative time range options and set custom absolute time ranges\n- Useful keyboard shortcuts for dashboards: \n   - `Ctrl+S` : Saves the current dashboard\n   - `f`: Opens the dashboard finder / search\n   - `d+s`: Dashboard settings",
+				"mode": "markdown"
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [],
+			"title": "",
+			"transparent": true,
+			"type": "text"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "green",
+						"mode": "shades"
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				}
+			},
+			"gridPos": {
+				"h": 3,
+				"w": 8,
+				"x": 0,
+				"y": 7
+			},
+			"id": 4,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"percentChangeColorMode": "standard",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"showPercentChange": false,
+				"textMode": "auto",
+				"wideLayout": true
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} | detected_level=\"info\" [$__range]))",
+					"legendFormat": "{{service_name}}",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Total Info Logs",
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "yellow",
+						"mode": "shades"
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				}
+			},
+			"gridPos": {
+				"h": 3,
+				"w": 8,
+				"x": 8,
+				"y": 7
+			},
+			"id": 5,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"percentChangeColorMode": "standard",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"showPercentChange": false,
+				"textMode": "auto",
+				"wideLayout": true
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} | detected_level=\"warn\" [$__range]))",
+					"legendFormat": "{{service_name}}",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Total Warn Logs",
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "red",
+						"mode": "shades"
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				}
+			},
+			"gridPos": {
+				"h": 3,
+				"w": 8,
+				"x": 16,
+				"y": 7
+			},
+			"id": 3,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"percentChangeColorMode": "standard",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"showPercentChange": false,
+				"textMode": "auto",
+				"wideLayout": true
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} | detected_level=\"error\" [$__range]))",
+					"legendFormat": "{{service_name}}",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Total Error Logs",
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "text",
+						"mode": "fixed"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "hidden",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "bars",
+						"fillOpacity": 100,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "linear",
+						"lineWidth": 2,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "auto",
+						"showValues": false,
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "normal"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "text",
+								"value": 0
+							}
+						]
+					},
+					"unit": "short"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "error"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "info"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "green",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "warn"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 4,
+				"w": 24,
+				"x": 0,
+				"y": 10
+			},
+			"id": 1,
+			"interval": "1m",
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} [$__auto])) by (detected_level)",
+					"legendFormat": "{{ detected_level }}",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Logs",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						}
+					}
+				}
+			},
+			"gridPos": {
+				"h": 7,
+				"w": 6,
+				"x": 0,
+				"y": 14
+			},
+			"id": 13,
+			"interval": "1m",
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"pieType": "pie",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"sort": "desc",
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} [$__range])) by (detected_level)",
+					"legendFormat": "{{detected_level}}",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Distribution by Log Level",
+			"type": "piechart"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						}
+					}
+				}
+			},
+			"gridPos": {
+				"h": 7,
+				"w": 6,
+				"x": 6,
+				"y": 14
+			},
+			"id": 14,
+			"interval": "1m",
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"pieType": "pie",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"sort": "desc",
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} | json | httpRequest_path=~\"/api/.*\" [$__range])) by (httpRequest_path)",
+					"legendFormat": "{{ httpRequest_path }}",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Distribution by Path",
+			"type": "piechart"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						}
+					}
+				}
+			},
+			"gridPos": {
+				"h": 7,
+				"w": 6,
+				"x": 12,
+				"y": 14
+			},
+			"id": 15,
+			"interval": "1m",
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"pieType": "pie",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"sort": "desc",
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} | json | httpRequest_path=~\"/api/.*\" [$__range])) by (httpRequest_method)",
+					"legendFormat": "{{httpRequest_method}}",
+					"queryType": "range",
+					"refId": "Errors"
+				}
+			],
+			"title": "Distribution by Method",
+			"type": "piechart"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						}
+					}
+				}
+			},
+			"gridPos": {
+				"h": 7,
+				"w": 6,
+				"x": 18,
+				"y": 14
+			},
+			"id": 16,
+			"interval": "1m",
+			"options": {
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"pieType": "pie",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"sort": "desc",
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} | json | httpRequest_path=~\"/api/.*\" [$__range])) by (httpResponse_status)",
+					"legendFormat": "200",
+					"queryType": "range",
+					"refId": "Errors"
+				}
+			],
+			"title": "Distribution by Status Code",
+			"type": "piechart"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"gridPos": {
+				"h": 10,
+				"w": 24,
+				"x": 0,
+				"y": 21
+			},
+			"id": 9,
+			"options": {
+				"dedupStrategy": "none",
+				"enableInfiniteScrolling": false,
+				"enableLogDetails": true,
+				"prettifyLogMessage": false,
+				"showCommonLabels": false,
+				"showControls": false,
+				"showFieldSelector": false,
+				"showLabels": false,
+				"showLevel": true,
+				"showTime": true,
+				"sortOrder": "Descending",
+				"timestampResolution": "ms",
+				"unwrappedColumns": false,
+				"wrapLogMessage": false
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "builder",
+					"expr": "{service_namespace=\"quickpizza\"} |= ``",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "",
+			"type": "logs"
+		}
+	],
+	"preload": false,
+	"refresh": "",
+	"schemaVersion": 42,
+	"tags": [
+		"Logs"
+	],
+	"time": {
+		"from": "now-1h",
+		"to": "now"
+	},
+	"timepicker": {
+		"refresh_intervals": [
+			"5s",
+			"10s",
+			"30s",
+			"1m",
+			"5m",
+			"15m",
+			"30m",
+			"1h",
+			"2h",
+			"1d"
+		]
+	},
+	"timezone": "browser",
+	"title": "QuickPizza Logs",
+	"version": 1,
+	"uid": "quickpizza-logs",
+	"id": 898112275218432
+}

--- a/deployments/docker-compose/grafana-local-stack/grafana/dashboards/definitions/quickpizza_overview.json
+++ b/deployments/docker-compose/grafana-local-stack/grafana/dashboards/definitions/quickpizza_overview.json
@@ -1,0 +1,733 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": {
+					"type": "grafana",
+					"uid": "-- Grafana --"
+				},
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 0,
+	"liveNow": false,
+	"panels": [
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 0
+			},
+			"id": 17,
+			"title": "Overview",
+			"type": "row"
+		},
+		{
+			"gridPos": {
+				"h": 4,
+				"w": 24,
+				"x": 0,
+				"y": 1
+			},
+			"id": 2,
+			"options": {
+				"code": {
+					"language": "plaintext",
+					"showLineNumbers": false,
+					"showMiniMap": false
+				},
+				"content": "# Welcome to the QuickPizza SRE Demo!\n\nThis dashboard includes an overview of the architecture, as well as some high level stats about the application.\nIt should serve as an entrypoint to view the health of the system at a quick glance.\n\nYou can try out the application at [quickpizza.grafana.fun](https://quickpizza.grafana.fun/)\n",
+				"mode": "markdown"
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [],
+			"title": "",
+			"transparent": true,
+			"type": "text"
+		},
+		{
+			"datasource": {
+				"type": "tempo",
+				"uid": "tempo"
+			},
+			"gridPos": {
+				"h": 12,
+				"w": 24,
+				"x": 0,
+				"y": 5
+			},
+			"id": 1,
+			"options": {
+				"edges": {},
+				"layoutAlgorithm": "layered",
+				"nodes": {
+					"arcs": []
+				},
+				"zoomMode": "cooperative"
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "tempo",
+						"uid": "tempo"
+					},
+					"filters": [
+						{
+							"id": "8de6ae50",
+							"operator": "=",
+							"scope": "span"
+						}
+					],
+					"limit": 20,
+					"queryType": "serviceMap",
+					"refId": "A",
+					"serviceMapQuery": "{service_namespace=\"quickpizza\"}"
+				}
+			],
+			"title": "",
+			"transparent": true,
+			"type": "nodeGraph"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"description": "This panel summarizes request duration and rates across all microservices. Check out the App Observability plugin for more details.",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"custom": {
+						"align": "auto",
+						"cellOptions": {
+							"type": "auto"
+						},
+						"footer": {
+							"reducers": []
+						},
+						"inspect": false
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Duration, p95"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "unit",
+								"value": "s"
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Rate"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "blue",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "unit",
+								"value": "reqps"
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Errors"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "unit",
+								"value": "percentunit"
+							},
+							{
+								"id": "decimals",
+								"value": 0
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 24,
+				"x": 0,
+				"y": 17
+			},
+			"id": 9,
+			"options": {
+				"cellHeight": "sm",
+				"frameIndex": 0,
+				"showHeader": true
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{service_namespace=\"quickpizza\"} [$__rate_interval])) by (le,service_name))",
+					"instant": false,
+					"legendFormat": "__auto",
+					"range": true,
+					"refId": "Duration"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "(sum(rate(http_server_request_duration_seconds_count{service_namespace=\"quickpizza\", http_response_status_code=~\"(4|5)..\"} [$__rate_interval])) by (service_name) OR sum(rate(http_server_request_duration_seconds_count{service_namespace=\"quickpizza\"} [$__rate_interval])) by (service_name) * 0) / sum(rate(http_server_request_duration_seconds_count{service_namespace=\"quickpizza\"} [$__rate_interval])) by (service_name)",
+					"instant": false,
+					"legendFormat": "__auto",
+					"range": true,
+					"refId": "Errors"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "sum(rate(http_server_request_duration_seconds_count{service_namespace=\"quickpizza\"} [$__rate_interval])) by (service_name)",
+					"instant": false,
+					"legendFormat": "__auto",
+					"range": true,
+					"refId": "Rate"
+				}
+			],
+			"title": "",
+			"transformations": [
+				{
+					"id": "timeSeriesTable",
+					"options": {}
+				},
+				{
+					"id": "joinByField",
+					"options": {
+						"byField": "service_name",
+						"mode": "outer"
+					}
+				},
+				{
+					"id": "organize",
+					"options": {
+						"excludeByName": {},
+						"indexByName": {
+							"Trend #Duration": 3,
+							"Trend #Errors": 2,
+							"Trend #Rate": 1,
+							"service_name": 0
+						},
+						"renameByName": {
+							"Trend #Duration": "Duration, p95",
+							"Trend #Errors": "Errors",
+							"Trend #Rate": "Rate",
+							"service_name": "Service"
+						}
+					}
+				}
+			],
+			"transparent": true,
+			"type": "table"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 25
+			},
+			"id": 18,
+			"title": "Logs",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "text",
+						"mode": "fixed"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "hidden",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "bars",
+						"fillOpacity": 100,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "linear",
+						"lineWidth": 2,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "auto",
+						"showValues": false,
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "normal"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "text",
+								"value": 0
+							}
+						]
+					},
+					"unit": "short"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "error"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "info"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "green",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "warn"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 4,
+				"w": 24,
+				"x": 0,
+				"y": 26
+			},
+			"id": 12,
+			"interval": "1m",
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "sum(count_over_time({service_namespace=\"quickpizza\"} [$__auto])) by (detected_level)",
+					"legendFormat": "{{ detected_level }}",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "Logs",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "loki",
+				"uid": "loki"
+			},
+			"gridPos": {
+				"h": 11,
+				"w": 24,
+				"x": 0,
+				"y": 30
+			},
+			"id": 10,
+			"options": {
+				"dedupStrategy": "none",
+				"enableInfiniteScrolling": false,
+				"enableLogDetails": true,
+				"prettifyLogMessage": false,
+				"showCommonLabels": false,
+				"showControls": false,
+				"showFieldSelector": false,
+				"showLabels": false,
+				"showLevel": true,
+				"showTime": true,
+				"sortOrder": "Descending",
+				"timestampResolution": "ms",
+				"unwrappedColumns": false,
+				"wrapLogMessage": false
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "loki",
+						"uid": "loki"
+					},
+					"editorMode": "code",
+					"expr": "{namespace=\"quickpizza\"} | json | httpRequest_method != \"\" | line_format `[{{.service_name}}] {{.httpRequest_method}} {{.httpRequest_path}} {{if .traceID}}[traceID={{.traceID}}]{{end}}`",
+					"queryType": "range",
+					"refId": "A"
+				}
+			],
+			"title": "",
+			"type": "logs"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 41
+			},
+			"id": 19,
+			"title": "⏱️ Request Timings",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "blue",
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "hidden",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"gradientMode": "opacity",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "smooth",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"showValues": false,
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							}
+						]
+					},
+					"unit": "reqps"
+				}
+			},
+			"gridPos": {
+				"h": 3,
+				"w": 20,
+				"x": 0,
+				"y": 42
+			},
+			"id": 13,
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "sum(rate(http_server_request_duration_seconds_count{service_namespace=\"quickpizza\",service_name=~\".*public-api\"}[$__rate_interval])) by (service_name)",
+					"legendFormat": "Total",
+					"range": true,
+					"refId": "A"
+				}
+			],
+			"title": "Request Volume",
+			"type": "timeseries"
+		},
+		{
+			"gridPos": {
+				"h": 11,
+				"w": 4,
+				"x": 20,
+				"y": 42
+			},
+			"id": 16,
+			"options": {
+				"code": {
+					"language": "plaintext",
+					"showLineNumbers": false,
+					"showMiniMap": false
+				},
+				"content": "# About _Request Timings_\n\nThe _Heatmap_ to the left displays request timings and their frequency.\n\nIt can be read as follows:\n\n* The Y Axis shows the duration of the requests. Blocks found higher up, represent a longer request duration.\n* The color of the blocks represent the amount of requests in the respective range of timings. A lighter block contains more requests than a dark one.\n\nWith a higher request rate, the variance between response times will increase. Ideally, a clear line at the bottom should be visible. This means that most requests finished quickly.",
+				"mode": "markdown"
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [],
+			"title": "",
+			"type": "text"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"custom": {
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"scaleDistribution": {
+							"type": "linear"
+						}
+					}
+				}
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 20,
+				"x": 0,
+				"y": 45
+			},
+			"id": 11,
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"calculate": false,
+				"cellGap": 1,
+				"color": {
+					"exponent": 0.5,
+					"fill": "dark-green",
+					"mode": "scheme",
+					"reverse": false,
+					"scale": "exponential",
+					"scheme": "Warm",
+					"steps": 128
+				},
+				"exemplars": {
+					"color": "rgba(255,0,255,0.7)"
+				},
+				"filterValues": {
+					"le": 1e-9
+				},
+				"legend": {
+					"show": true
+				},
+				"rowsFrame": {
+					"layout": "auto"
+				},
+				"tooltip": {
+					"mode": "single",
+					"showColorScale": false,
+					"yHistogram": false
+				},
+				"yAxis": {
+					"axisPlacement": "left",
+					"reverse": false,
+					"unit": "s"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"exemplar": false,
+					"expr": "sum(increase(quickpizza_server_http_request_duration_seconds_bucket{service_namespace=\"quickpizza\",service_name=~\".*public-api\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"instant": false,
+					"legendFormat": "{{le}}",
+					"range": true,
+					"refId": "A"
+				}
+			],
+			"title": "Request Latency Heatmap",
+			"type": "heatmap"
+		}
+	],
+	"preload": false,
+	"refresh": "1m",
+	"schemaVersion": 42,
+	"time": {
+		"from": "now-3h",
+		"to": "now"
+	},
+	"timepicker": {
+		"refresh_intervals": [
+			"5s",
+			"10s",
+			"30s",
+			"1m",
+			"5m",
+			"15m",
+			"30m",
+			"1h",
+			"2h",
+			"1d"
+		]
+	},
+	"timezone": "browser",
+	"title": "QuickPizza Overview",
+	"version": 1,
+	"uid": "quickpizza-overview",
+	"id": 923605801357312
+}

--- a/deployments/docker-compose/grafana-local-stack/grafana/dashboards/definitions/quickpizza_performance.json
+++ b/deployments/docker-compose/grafana-local-stack/grafana/dashboards/definitions/quickpizza_performance.json
@@ -1,0 +1,684 @@
+{
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": {
+					"type": "grafana",
+					"uid": "-- Grafana --"
+				},
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 1,
+	"links": [],
+	"liveNow": false,
+	"panels": [
+		{
+			"gridPos": {
+				"h": 3,
+				"w": 18,
+				"x": 0,
+				"y": 0
+			},
+			"id": 53,
+			"options": {
+				"code": {
+					"language": "plaintext",
+					"showLineNumbers": false,
+					"showMiniMap": false
+				},
+				"content": "# Performance & RED Metrics\nThis dashboard shows the [RED metrics](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/) for all components. Use the selector above this panel to change the service you are inspecting.\nIt also summarizes request volume and database query count for quick analysis.",
+				"mode": "markdown"
+			},
+			"pluginVersion": "13.0.1",
+			"transparent": true,
+			"type": "text"
+		},
+		{
+			"gridPos": {
+				"h": 1,
+				"w": 6,
+				"x": 18,
+				"y": 0
+			},
+			"id": 60,
+			"options": {
+				"code": {
+					"language": "plaintext",
+					"showLineNumbers": false,
+					"showMiniMap": false
+				},
+				"content": "",
+				"mode": "markdown"
+			},
+			"pluginVersion": "13.0.1",
+			"transparent": true,
+			"type": "text"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisGridShow": true,
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"gradientMode": "opacity",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "smooth",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"showValues": false,
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 9,
+				"w": 8,
+				"x": 0,
+				"y": 3
+			},
+			"id": 1,
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "histogram_quantile(0.95,sum(rate(http_server_request_duration_seconds_bucket{service_name=~\".*public-api\"}[$__rate_interval])) by (le))",
+					"instant": false,
+					"interval": "1m",
+					"legendFormat": "P95 ",
+					"range": true,
+					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "histogram_quantile(0.99,sum(rate(http_server_request_duration_seconds_bucket{service_name=~\".*public-api\"}[$__rate_interval])) by (le))",
+					"instant": false,
+					"interval": "1m",
+					"legendFormat": "P99",
+					"range": true,
+					"refId": "B"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "histogram_quantile(0.90,sum(rate(http_server_request_duration_seconds_bucket{service_name=~\".*public-api\"}[$__rate_interval])) by (le))",
+					"instant": false,
+					"interval": "1m",
+					"legendFormat": "P90",
+					"range": true,
+					"refId": "C"
+				}
+			],
+			"title": "Frontend Response Latency",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							}
+						]
+					},
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 9,
+				"w": 16,
+				"x": 8,
+				"y": 3
+			},
+			"id": 12,
+			"options": {
+				"colorMode": "background",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"percentChangeColorMode": "standard",
+				"reduceOptions": {
+					"calcs": [
+						"lastNotNull"
+					],
+					"fields": "",
+					"values": false
+				},
+				"showPercentChange": false,
+				"textMode": "auto",
+				"wideLayout": true
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "sum(rate(quickpizza_server_http_request_duration_seconds_count{service_namespace=\"quickpizza\", service_name=~\"$component\"}[$__rate_interval])) by (service_name)",
+					"instant": false,
+					"interval": "1m",
+					"legendFormat": "{{service_name}}",
+					"range": true,
+					"refId": "A"
+				}
+			],
+			"title": "Request Volume",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 12
+			},
+			"id": 61,
+			"repeat": "component",
+			"title": "Details for $component",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"gradientMode": "opacity",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "smooth",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"showValues": false,
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "reqps"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 10,
+				"w": 8,
+				"x": 0,
+				"y": 13
+			},
+			"id": 21,
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"legend": {
+					"calcs": [],
+					"displayMode": "table",
+					"placement": "right",
+					"showLegend": true
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "sum(rate(quickpizza_server_http_request_duration_seconds_count{service_namespace=\"quickpizza\", service_name=\"$component\"}[$__rate_interval])) by (path)",
+					"instant": false,
+					"legendFormat": "__auto",
+					"range": true,
+					"refId": "A"
+				}
+			],
+			"title": "Request rate by path",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"gradientMode": "opacity",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "smooth",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"showValues": false,
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 10,
+				"w": 8,
+				"x": 8,
+				"y": 13
+			},
+			"id": 11,
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "histogram_quantile(0.95,sum(rate(http_server_request_duration_seconds_bucket{service_namespace=\"quickpizza\", service_name=\"$component\"}[$__rate_interval])) by (le))",
+					"instant": false,
+					"legendFormat": "P95 - $component",
+					"range": true,
+					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "histogram_quantile(0.99,sum(rate(http_server_request_duration_seconds_bucket{service_namespace=\"quickpizza\", service_name=\"$component\"}[$__rate_interval])) by (le))",
+					"instant": false,
+					"legendFormat": "P99 - $component",
+					"range": true,
+					"refId": "B"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "sum(rate(http_server_request_duration_seconds_sum{service_namespace=\"quickpizza\", service_name=\"$component\"}[$__rate_interval])) / sum(rate(http_server_request_duration_seconds_count{service_namespace=\"quickpizza\", service_name=\"$component\"}[$__rate_interval]))",
+					"instant": false,
+					"legendFormat": "Avg - $component",
+					"range": true,
+					"refId": "C"
+				}
+			],
+			"title": "Response Latency",
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "prometheus",
+				"uid": "prometheus"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "dark-red",
+						"mode": "fixed"
+					},
+					"custom": {
+						"axisBorderShow": false,
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"barWidthFactor": 0.6,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"gradientMode": "scheme",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"insertNulls": false,
+						"lineInterpolation": "smooth",
+						"lineWidth": 2,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "auto",
+						"showValues": false,
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"max": 1,
+					"min": 0,
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": 0
+							}
+						]
+					},
+					"unit": "percentunit"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 10,
+				"w": 8,
+				"x": 16,
+				"y": 13
+			},
+			"id": 34,
+			"options": {
+				"annotations": {
+					"clustering": -1,
+					"multiLane": false
+				},
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"hideZeros": false,
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "13.0.1",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "prometheus"
+					},
+					"editorMode": "code",
+					"expr": "(sum(rate(quickpizza_server_http_request_duration_seconds_sum{service_name=\"$component\",status!~\"(2..|0)\"}[$__rate_interval])) / sum(rate(quickpizza_server_http_request_duration_seconds_sum{service_name=\"$component\"}[$__rate_interval]))) or vector(0)",
+					"instant": false,
+					"legendFormat": "Error Rate",
+					"range": true,
+					"refId": "A"
+				}
+			],
+			"title": "Error Rate",
+			"type": "timeseries"
+		},
+		{
+			"gridPos": {
+				"h": 2,
+				"w": 24,
+				"x": 0,
+				"y": 23
+			},
+			"id": 59,
+			"options": {
+				"code": {
+					"language": "plaintext",
+					"showLineNumbers": false,
+					"showMiniMap": false
+				},
+				"content": "---",
+				"mode": "markdown"
+			},
+			"pluginVersion": "13.0.1",
+			"transparent": true,
+			"type": "text"
+		}
+	],
+	"preload": false,
+	"refresh": "",
+	"schemaVersion": 42,
+	"tags": [],
+	"templating": {
+		"list": [
+			{
+				"allowCustomValue": true,
+				"current": {},
+				"datasource": {
+					"type": "prometheus",
+					"uid": "prometheus"
+				},
+				"definition": "label_values(http_server_request_duration_seconds_count{\"service_namespace\"=\"quickpizza\"},service_name)",
+				"includeAll": true,
+				"label": "Component",
+				"multi": true,
+				"name": "component",
+				"options": [],
+				"query": {
+					"query": "label_values(http_server_request_duration_seconds_count{\"service_namespace\"=\"quickpizza\"},service_name)",
+					"refId": "PrometheusVariableQueryEditor-VariableQuery"
+				},
+				"refresh": 1,
+				"regex": "",
+				"type": "query"
+			}
+		]
+	},
+	"time": {
+		"from": "now-6h",
+		"to": "now"
+	},
+	"timepicker": {
+		"refresh_intervals": [
+			"5s",
+			"10s",
+			"30s",
+			"1m",
+			"5m",
+			"15m",
+			"30m",
+			"1h",
+			"2h",
+			"1d"
+		]
+	},
+	"timezone": "browser",
+	"title": "QuickPizza Service Performance",
+	"uid": "a581fb5a-df38-45d7-83cb-d10835930fa1",
+	"version": 3,
+	"weekStart": ""
+}

--- a/k6/run-tests.sh
+++ b/k6/run-tests.sh
@@ -33,7 +33,7 @@ for test in $TESTS; do
 	# Disable thresholds because some threshold examples fail
     echo "Running: $test"
     rm -f $LOGS
-	$K6_PATH run --no-thresholds -e BASE_URL="$BASE_URL" --log-output=file=$LOGS --log-format=json -w --no-summary "$test"
+	$K6_PATH run --no-thresholds -e BASE_URL="$BASE_URL" --log-output=file=$LOGS --log-format=json -w --summary-mode=disabled "$test"
     k6_exit_code=$?
 
     # Only check error logs if logs file is not empty.


### PR DESCRIPTION
Screenshots when running QP on monolithic model



<img width="1416" height="863" alt="Screenshot 2026-05-13 at 17 36 32" src="https://github.com/user-attachments/assets/4bd536a0-21ec-46a0-bfc5-df57ed6ca5b0" />
<img width="1344" height="770" alt="Screenshot 2026-05-13 at 17 36 19" src="https://github.com/user-attachments/assets/689d72a1-16d7-4602-9b76-9460e438e28a" />
<img width="1410" height="878" alt="Screenshot 2026-05-13 at 17 36 09" src="https://github.com/user-attachments/assets/613ca4f8-76a9-4ec1-8a74-9d620223ae9f" />
<img width="543" height="152" alt="Screenshot 2026-05-13 at 17 36 00" src="https://github.com/user-attachments/assets/070e0f93-c9ad-4b2d-9ff2-086dcb4fdcaf" />
