### PR TITLE
chore: update go to v1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ENV PUBLIC_BACKEND_WS_ENDPOINT=${PUBLIC_BACKEND_WS_ENDPOINT}
 RUN npm install && \
     npm run build
 
-# golang:1.25-alpine
-FROM golang:1.25-alpine@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931 AS builder
+# golang:1.26-alpine
+FROM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 WORKDIR /app
 COPY . ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/quickpizza
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/go-chi/chi/v5 v5.2.4

--- a/k6/extensions/quickpizzaext/go.mod
+++ b/k6/extensions/quickpizzaext/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/quickpizza/extensions/quickpizzaext
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/grafana/quickpizza v0.0.0


### PR DESCRIPTION
closes https://github.com/grafana/quickpizza/pull/474