### PR TITLE
feat: add configurable HTTP timeouts for public-api and recommedations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,16 +79,37 @@ Comprehensive observability built-in:
 - `QUICKPIZZA_OTLP_ENDPOINT` - OpenTelemetry collector endpoint
 - `QUICKPIZZA_PYROSCOPE_ENDPOINT` - Pyroscope server for profiling
 - `QUICKPIZZA_DB` - Database connection string
+- `QUICKPIZZA_PUBLIC_API_TIMEOUT` - Wraps the public-api handler with `http.TimeoutHandler`; unset by default (no timeout). Returns **503** when the deadline fires. In monolith mode it covers the full request; in microservice mode it also covers the ReverseProxy leg to internal services. Uses Go duration format (e.g. `3s`).
+- `QUICKPIZZA_RECOMMENDATIONS_HTTP_CLIENT_TIMEOUT` - Timeout on the HTTP client used by the recommendations service to call catalog and copy (default: `1s`). In monolith mode these are localhost calls; in microservice mode they are cross-service calls.
+- `QUICKPIZZA_RECOMMENDATIONS_RETRIES` - Max retries for recommendations → catalog/copy calls (renamed from `QUICKPIZZA_RETRIES`).
+- `QUICKPIZZA_RECOMMENDATIONS_BACKOFF_MIN` - Min backoff duration between retries (renamed from `QUICKPIZZA_BACKOFF_MIN`).
+- `QUICKPIZZA_RECOMMENDATIONS_BACKOFF_MAX` - Max backoff duration between retries (renamed from `QUICKPIZZA_BACKOFF_MAX`).
 
 ## Development Notes
 
-### Error Injection
-The application supports error injection via HTTP headers for testing:
+### Fault Injection
+The application supports fault injection via HTTP headers and environment variables.
+
+**HTTP headers** (per-request, via `pkg/errorinjector/`):
 - `x-error-record-recommendation` - Trigger recommendation errors
 - `x-error-get-ingredients` - Trigger ingredient retrieval errors
 - `x-delay-record-recommendation` - Add delays to recommendations
 - `x-delay-get-ingredients` - Add delays to ingredient retrieval
 - Add `-percentage` suffix to any error header to control probability
+
+**Environment variables** (process-wide, value in milliseconds):
+- `QUICKPIZZA_DELAY_RECOMMENDATIONS` - Delay all recommendations endpoints
+- `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_GET` - Delay `GET /api/pizza/{id}`
+- `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST` - Delay `POST /api/pizza` (pizza generation)
+- `QUICKPIZZA_DELAY_COPY` - Delay all copy endpoints
+- `QUICKPIZZA_DELAY_COPY_API_QUOTES` - Delay `GET /api/quotes`
+- `QUICKPIZZA_DELAY_COPY_API_NAMES` - Delay pizza name generation
+- `QUICKPIZZA_DELAY_COPY_API_ADJECTIVES` - Delay adjective generation
+- `QUICKPIZZA_DELAY_FRONTEND_CSS_ASSETS` - Delay CSS asset serving
+- `QUICKPIZZA_DELAY_FRONTEND_PNG_ASSETS` - Delay PNG asset serving
+- `QUICKPIZZA_FAIL_RATE_RECOMMENDATIONS_API_PIZZA_POST` - Random failure rate (0-100) for `POST /api/pizza`
+
+**Timeout testing example**: set `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST=3000` with `QUICKPIZZA_PUBLIC_API_TIMEOUT=1s` to trigger 503 responses on pizza requests.
 
 ### Frontend Integration
 - Frontend is built with SvelteKit and embedded in the Go binary

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,10 +66,6 @@ func main() {
 		}
 	}
 
-	// Create an HTTP client configured from env vars.
-	// If no specific env vars are set, this will return a http client that does not perform any retries.
-	httpCli := clientFromEnv()
-
 	// Create the QuickPizza server.
 	server := qphttp.NewServer(profilingEnabled, otelInstaller)
 
@@ -141,8 +137,9 @@ func main() {
 	// This URL is automatically set to `localhost` if Recommendations is enabled at the same time as either of those.
 	// If they are not, URLs are sourced from QUICKPIZZA_CATALOG_ENDPOINT and QUICKPIZZA_COPY_ENDPOINT.
 	if envServe("QUICKPIZZA_ENABLE_RECOMMENDATIONS_SERVICE") {
-		catalogClient := qphttp.NewCatalogClient(envEndpoint("QUICKPIZZA_ENABLE_CATALOG_SERVICE", "QUICKPIZZA_CATALOG_ENDPOINT")).WithClient(httpCli)
-		copyClient := qphttp.NewCopyClient(envEndpoint("QUICKPIZZA_ENABLE_COPY_SERVICE", "QUICKPIZZA_COPY_ENDPOINT")).WithClient(httpCli)
+		recommendationsHTTPClient := newRecommendationsHTTPClient()
+		catalogClient := qphttp.NewCatalogClient(envEndpoint("QUICKPIZZA_ENABLE_CATALOG_SERVICE", "QUICKPIZZA_CATALOG_ENDPOINT")).WithClient(recommendationsHTTPClient)
+		copyClient := qphttp.NewCopyClient(envEndpoint("QUICKPIZZA_ENABLE_COPY_SERVICE", "QUICKPIZZA_COPY_ENDPOINT")).WithClient(recommendationsHTTPClient)
 
 		server.AddRecommendations(catalogClient, copyClient)
 	}
@@ -160,22 +157,31 @@ func main() {
 
 	listen := ":3333"
 	slog.Info("Starting QuickPizza", "listenAddress", listen)
-	err := http.ListenAndServe(listen, server)
+
+	handler := http.Handler(server)
+	if publicAPITimeout := envDuration("QUICKPIZZA_PUBLIC_API_TIMEOUT"); publicAPITimeout > 0 {
+		handler = http.TimeoutHandler(handler, publicAPITimeout, "request timed out")
+	}
+
+	err := http.ListenAndServe(listen, handler)
 	if err != nil {
 		slog.Error("Running HTTP server", "err", err)
 		os.Exit(1)
 	}
 }
 
-// clientFromEnv returns an *http.Client implementation according to the retries and backoff specified in env vars.
-func clientFromEnv() *http.Client {
-	// Configure an underlying client with otel transport.
-	// Otel transport takes care of generating spans for outcoming requests, as well as propagating trace IDs on those
-	// requests.
+// newRecommendationsHTTPClient returns an HTTP client used by the recommendations service
+// to call catalog and copy. Configured via:
+//   - QUICKPIZZA_RECOMMENDATIONS_HTTP_CLIENT_TIMEOUT - request timeout (default 1s)
+//   - QUICKPIZZA_RECOMMENDATIONS_RETRIES - max retries
+//   - QUICKPIZZA_RECOMMENDATIONS_BACKOFF_MIN/MAX - retry backoff bounds
+//
+// Use QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST (milliseconds) together with
+// QUICKPIZZA_PUBLIC_API_TIMEOUT to simulate timeout scenarios.
+func newRecommendationsHTTPClient() *http.Client {
 	httpClient := &http.Client{
 		Transport: otelhttp.NewTransport(
-			nil, // Default transport.
-			// Propagator will retrieve the tracer used in the server from memory.
+			nil,
 			otelhttp.WithPropagators(propagation.NewCompositeTextMapPropagator(
 				propagation.TraceContext{},
 				propagation.Baggage{},
@@ -183,30 +189,25 @@ func clientFromEnv() *http.Client {
 		),
 	}
 
-	timeout := envDuration("QUICKPIZZA_TIMEOUT")
-	if timeout == 0 {
-		timeout = time.Second
+	clientTimeout := envDuration("QUICKPIZZA_RECOMMENDATIONS_HTTP_CLIENT_TIMEOUT")
+	if clientTimeout == 0 {
+		clientTimeout = time.Second
 	}
-
-	httpClient.Timeout = timeout
+	httpClient.Timeout = clientTimeout
 
 	retriableClient := retryablehttp.NewClient()
 	retriableClient.Logger = nil
-	// Configure retryablehttp to use the instrumented client.
 	// Retries occur at the retriableClient layer, so instrumentation will see failures from httpClient.
 	retriableClient.HTTPClient = httpClient
+	retriableClient.RetryMax = envInt("QUICKPIZZA_RECOMMENDATIONS_RETRIES")
 
-	retriableClient.RetryMax = envInt("QUICKPIZZA_RETRIES")
-
-	if retryMin := envDuration("QUICKPIZZA_BACKOFF_MIN"); retryMin != 0 {
+	if retryMin := envDuration("QUICKPIZZA_RECOMMENDATIONS_BACKOFF_MIN"); retryMin != 0 {
 		retriableClient.RetryWaitMin = retryMin
 	}
-
-	if retryMax := envDuration("QUICKPIZZA_BACKOFF_MAX"); retryMax != 0 {
+	if retryMax := envDuration("QUICKPIZZA_RECOMMENDATIONS_BACKOFF_MAX"); retryMax != 0 {
 		retriableClient.RetryWaitMax = retryMax
 	}
 
-	// Return a stdlib client that uses retryablehttp as transport.
 	return retriableClient.StandardClient()
 }
 

--- a/deployments/terraform/qp-public-api.tf
+++ b/deployments/terraform/qp-public-api.tf
@@ -81,6 +81,10 @@ resource "kubernetes_deployment_v1" "public_api" {
             value = "1"
           }
           env {
+            name  = "QUICKPIZZA_PUBLIC_API_TIMEOUT"
+            value = "10s"
+          }
+          env {
             name  = "QUICKPIZZA_OTEL_SERVICE_NAME"
             value = "public-api"
           }

--- a/pkg/web/src/routes/+page.svelte
+++ b/pkg/web/src/routes/+page.svelte
@@ -163,17 +163,24 @@ async function getPizza() {
 		headers,
 		credentials: 'same-origin',
 	});
-	const json = await res.json();
 
 	rateResult = null;
 	errorResult = null;
 	if (!res.ok) {
 		pizza = '';
-		errorResult =
-			json.error || 'Failed to get pizza recommendation. Please try again.';
+		const contentType = res.headers.get('content-type') || '';
+		if (contentType.includes('application/json')) {
+			const json = await res.json();
+			errorResult =
+				json.error || 'Failed to get pizza recommendation. Please try again.';
+		} else {
+			const text = await res.text();
+			errorResult = `${res.status}: ${text || 'Failed to get pizza recommendation. Please try again.'}`;
+		}
 		window.faro?.api?.pushError(new Error(errorResult));
 		return;
 	}
+	const json = await res.json();
 
 	pizza = json;
 	const wsMsg = JSON.stringify({


### PR DESCRIPTION
- Adds QUICKPIZZA_PUBLIC_API_TIMEOUT to enforce a response deadline on the public-api service via http.TimeoutHandler. Returns a clean 503 when the deadline fires, visible in k6 metrics, traces, and Grafana dashboards. Unset by default to avoid breaking existing deployments.

- Renames QUICKPIZZA_RETRIES, QUICKPIZZA_BACKOFF_MIN/MAX, and the HTTP client timeout to QUICKPIZZA_RECOMMENDATIONS_* — these were always recommendations-only settings and the naming now makes that explicit.

