### PR TITLE
feat: use Go duration strings for QUICKPIZZA_DELAY_* env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ The application supports fault injection via HTTP headers and environment variab
 - `x-delay-get-ingredients` - Add delays to ingredient retrieval
 - Add `-percentage` suffix to any error header to control probability
 
-**Environment variables** (process-wide, value in milliseconds):
+**Environment variables** (process-wide, Go duration string, e.g. `500ms`, `2s`):
 - `QUICKPIZZA_DELAY_RECOMMENDATIONS` - Delay all recommendations endpoints
 - `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_GET` - Delay `GET /api/pizza/{id}`
 - `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST` - Delay `POST /api/pizza` (pizza generation)
@@ -109,7 +109,7 @@ The application supports fault injection via HTTP headers and environment variab
 - `QUICKPIZZA_DELAY_FRONTEND_PNG_ASSETS` - Delay PNG asset serving
 - `QUICKPIZZA_FAIL_RATE_RECOMMENDATIONS_API_PIZZA_POST` - Random failure rate (0-100) for `POST /api/pizza`
 
-**Timeout testing example**: set `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST=3000` with `QUICKPIZZA_PUBLIC_API_TIMEOUT=1s` to trigger 503 responses on pizza requests.
+**Timeout testing example**: set `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST=3s` with `QUICKPIZZA_PUBLIC_API_TIMEOUT=1s` to trigger 503 responses on pizza requests.
 
 ### Frontend Integration
 - Frontend is built with SvelteKit and embedded in the Go binary

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -176,7 +176,7 @@ func main() {
 //   - QUICKPIZZA_RECOMMENDATIONS_RETRIES - max retries
 //   - QUICKPIZZA_RECOMMENDATIONS_BACKOFF_MIN/MAX - retry backoff bounds
 //
-// Use QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST (milliseconds) together with
+// Use QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST (Go duration, e.g. "3s") together with
 // QUICKPIZZA_PUBLIC_API_TIMEOUT to simulate timeout scenarios.
 func newRecommendationsHTTPClient() *http.Client {
 	httpClient := &http.Client{

--- a/docs/inject-errors.md
+++ b/docs/inject-errors.md
@@ -9,9 +9,9 @@ You can inject delays to endpoints and assets using environment variables.
 This is useful for testing scenarios where you want to simulate slow responses across multiple endpoints. 
 
 ```shell
-export QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST=1000
+export QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST=1s
 ```
-The delay values should be specified in **milliseconds**.
+The delay values must be Go duration strings (e.g. `500ms`, `2s`, `1.5s`).
 
 The following environment variables are supported: 
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"log/slog"
 	"math/rand"
 	"os"
 	"strconv"
@@ -23,13 +24,19 @@ func GenerateAlphaNumToken(length int) string {
 	return string(data)
 }
 
-// DelayIfEnvSet applies a delay in milliseconds if the specified environment variable is set.
-// The environment variable should contain an integer value representing milliseconds.
+// DelayIfEnvSet sleeps for the duration specified by the environment variable.
+// The value must be a Go duration string (e.g. "500ms", "2s"). Invalid values are ignored.
 func DelayIfEnvSet(envVarName string) {
-	if delayStr, ok := os.LookupEnv(envVarName); ok {
-		delayMs, _ := strconv.Atoi(delayStr)
-		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+	delayStr, ok := os.LookupEnv(envVarName)
+	if !ok {
+		return
 	}
+	d, err := time.ParseDuration(delayStr)
+	if err != nil {
+		slog.Warn("invalid duration for env var, ignoring", "env", envVarName, "value", delayStr)
+		return
+	}
+	time.Sleep(d)
 }
 
 // FailRandomlyIfEnvSet checks if this request should fail based on a random percentage.


### PR DESCRIPTION
- `QUICKPIZZA_DELAY_*` env vars now accept Go duration strings (e.g. `500ms`, `2s`) instead of integer milliseconds
- `DelayIfEnvSet` uses `time.ParseDuration`; invalid values log a warning and are skipped
- Updates CLAUDE.md, docs/inject-errors.md, and cmd/main.go examples accordingly

## Breaking change

Any existing deployment using `QUICKPIZZA_DELAY_*=<integer>` must update to `<integer>ms` (e.g. `3000` → `3000ms` or `3s`).