### PR TITLE
chore: upgrade QuickPizza image to v0.15.27

### DIFF
--- a/.github/workflows/example_browser_tests.yaml
+++ b/.github/workflows/example_browser_tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 
@@ -65,7 +65,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_cli_flags_test.yaml
+++ b/.github/workflows/example_cli_flags_test.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_env_var.yaml
+++ b/.github/workflows/example_env_var.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3355:3333
 

--- a/.github/workflows/example_specific_k6_version.yaml
+++ b/.github/workflows/example_specific_k6_version.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_tests.yaml
+++ b/.github/workflows/example_tests.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 
@@ -36,7 +36,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_verify_scripts.yaml
+++ b/.github/workflows/example_verify_scripts.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.25@sha256:c992cf3796687f9a0dd1f9f6363156bafe5250334c919b8dae4d2ff8234df9b8 # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,54 @@ The application is specifically designed for k6 load testing:
 - Support for k6 browser testing
 - k6 extensions and examples
 - Prometheus output for k6 metrics correlation
+
+## Upgrading the QuickPizza Image Version
+
+When a new release is published to GHCR (e.g. `ghcr.io/grafana/quickpizza-local:0.15.27`), update the image version in all of the following locations:
+
+### Step 1: Fetch the image digests
+
+```bash
+docker buildx imagetools inspect ghcr.io/grafana/quickpizza-local:<NEW_VERSION>
+```
+
+From the output, extract:
+- **Index digest** (the top-level `Digest:` field) — used in Terraform.
+- **linux/amd64 digest** (the manifest entry for `Platform: linux/amd64`) — used in GitHub Actions workflows.
+
+### Step 2: Files to update
+
+**Docker Compose files** — plain tag, no digest (uses `${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:<VERSION>}` pattern):
+- `compose.grafana-local-stack.monolithic.yaml`
+- `compose.grafana-local-stack.microservices.yaml` (7 service entries)
+- `compose.grafana-cloud.monolithic.yaml`
+- `compose.grafana-cloud.microservices.yaml` (7 service entries)
+
+**GitHub Actions example workflow files** — `tag@sha256:<linux/amd64-digest>` format, with `# zizmor: ignore[unpinned-images]` comment:
+- `.github/workflows/example_tests.yaml` (2 occurrences)
+- `.github/workflows/example_browser_tests.yaml` (2 occurrences)
+- `.github/workflows/example_cli_flags_test.yaml`
+- `.github/workflows/example_env_var.yaml`
+- `.github/workflows/example_verify_scripts.yaml`
+- `.github/workflows/example_specific_k6_version.yaml`
+
+**Kubernetes deployment files** — plain tag, no digest:
+- `deployments/kubernetes/base/quickpizza/catalog.yaml`
+- `deployments/kubernetes/base/quickpizza/config.yaml`
+- `deployments/kubernetes/base/quickpizza/copy.yaml`
+- `deployments/kubernetes/base/quickpizza/grpc.yaml`
+- `deployments/kubernetes/base/quickpizza/public-api.yaml`
+- `deployments/kubernetes/base/quickpizza/recommendations.yaml`
+- `deployments/kubernetes/base/quickpizza/ws.yaml`
+
+**Terraform variables** — two fields, both using `tag@sha256:<index-digest>` format:
+- `deployments/terraform/variables.tf`: `quickpizza_image` default (full `tag@sha256:` string) and `quickpizza_image_version` default (plain version string)
+
+### Step 3: Verify completeness
+
+After editing, run:
+```bash
+grep -rn "quickpizza-local:" . --include="*.yaml" --include="*.yml" --include="*.tf" | grep -v "docker_publish"
+```
+
+Confirm all occurrences show the new version. The `docker_publish.yaml` workflow is exempt — it derives the version dynamically from git release tags.

--- a/compose.grafana-cloud.microservices.yaml
+++ b/compose.grafana-cloud.microservices.yaml
@@ -48,7 +48,7 @@ services:
       - grpc
 
   catalog:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: catalog
     labels:
       - "service.type=application"
@@ -68,7 +68,7 @@ services:
         condition: service_healthy
 
   config:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: config
     labels:
       - "service.type=application"
@@ -83,7 +83,7 @@ services:
       QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-QuickPizza}"
       QUICKPIZZA_CONF_FARO_INSTRUMENTATION_ENABLE_REPLAY: "${QUICKPIZZA_CONF_FARO_INSTRUMENTATION_ENABLE_REPLAY:-false}"
   copy:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: copy
     labels:
       - "service.type=application"
@@ -105,7 +105,7 @@ services:
         condition: service_started
 
   public-api:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: public-api
     labels:
       - "service.type=application"
@@ -119,7 +119,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "public-api"
 
   recommendations:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: recommendations
     labels:
       - "service.type=application"
@@ -131,7 +131,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "recommendations"
 
   ws:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: ws
     labels:
       - "service.type=application"
@@ -143,7 +143,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "ws"
 
   grpc:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: grpc
     labels:
       - "service.type=application"

--- a/compose.grafana-cloud.monolithic.yaml
+++ b/compose.grafana-cloud.monolithic.yaml
@@ -31,7 +31,7 @@ services:
   quickpizza:
     # The QUICKPIZZA_IMAGE env. variable enables the use of a locally built image,
     # created with `make docker-build`.
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     # Alloy reads `container_name` to relabel service name in telemetry.
     container_name: quickpizza
     labels:

--- a/compose.grafana-local-stack.microservices.yaml
+++ b/compose.grafana-local-stack.microservices.yaml
@@ -52,7 +52,7 @@ services:
       - grpc
 
   catalog:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: catalog
     labels:
       - "service.type=application"
@@ -69,7 +69,7 @@ services:
         condition: service_healthy
 
   config:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: config
     labels:
       - "service.type=application"
@@ -80,7 +80,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "config"
       QUICKPIZZA_OTEL_SERVICE_NAME: "config"
   copy:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: copy
     labels:
       - "service.type=application"
@@ -99,7 +99,7 @@ services:
         condition: service_started
 
   public-api:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: public-api
     labels:
       - "service.type=application"
@@ -113,7 +113,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "public-api"
 
   recommendations:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: recommendations
     labels:
       - "service.type=application"
@@ -125,7 +125,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "recommendations"
 
   ws:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: ws
     labels:
       - "service.type=application"
@@ -137,7 +137,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "ws"
 
   grpc:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: grpc
     labels:
       - "service.type=application"

--- a/compose.grafana-local-stack.monolithic.yaml
+++ b/compose.grafana-local-stack.monolithic.yaml
@@ -36,7 +36,7 @@ services:
   quickpizza:
     # The QUICKPIZZA_IMAGE env. variable enables the use of a locally built image,
     # created with `make docker-build`.
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.25}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
     container_name: quickpizza
     labels:
       - "service.type=application"

--- a/deployments/kubernetes/base/quickpizza/catalog.yaml
+++ b/deployments/kubernetes/base/quickpizza/catalog.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.25
+          image: ghcr.io/grafana/quickpizza-local:0.15.27
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/config.yaml
+++ b/deployments/kubernetes/base/quickpizza/config.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.25
+          image: ghcr.io/grafana/quickpizza-local:0.15.27
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/copy.yaml
+++ b/deployments/kubernetes/base/quickpizza/copy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.25
+          image: ghcr.io/grafana/quickpizza-local:0.15.27
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/grpc.yaml
+++ b/deployments/kubernetes/base/quickpizza/grpc.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.25
+          image: ghcr.io/grafana/quickpizza-local:0.15.27
           ports:
             - name: grpc
               containerPort: 3334

--- a/deployments/kubernetes/base/quickpizza/public-api.yaml
+++ b/deployments/kubernetes/base/quickpizza/public-api.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.25
+          image: ghcr.io/grafana/quickpizza-local:0.15.27
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/recommendations.yaml
+++ b/deployments/kubernetes/base/quickpizza/recommendations.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.25
+          image: ghcr.io/grafana/quickpizza-local:0.15.27
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/ws.yaml
+++ b/deployments/kubernetes/base/quickpizza/ws.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.25
+          image: ghcr.io/grafana/quickpizza-local:0.15.27
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/terraform/variables.tf
+++ b/deployments/terraform/variables.tf
@@ -45,14 +45,14 @@ variable "quickpizza_enforce_image_digest" {
 }
 
 variable "quickpizza_image" {
-  default     = "ghcr.io/grafana/quickpizza-local:0.15.25@sha256:a49ea625d8f1a58738ff1635f59d42b539f5d4f64b040ff974a6012aa7cf22f2"
+  default     = "ghcr.io/grafana/quickpizza-local:0.15.27@sha256:043ee6616699a9dd49e5a2c55be039c79c1cac2d14ec0ce34333169deced98ab"
   description = "The Image to use for the QuickPizza Demo Application. Must use tag@sha256:digest format when quickpizza_enforce_image_digest is true."
   nullable    = false
   type        = string
 }
 
 variable "quickpizza_image_version" {
-  default     = "0.15.25"
+  default     = "0.15.27"
   description = "The version of the QuickPizza image. Must match the tag in quickpizza_image when quickpizza_enforce_image_digest is true."
   nullable    = false
   type        = string


### PR DESCRIPTION
## Summary

Bumps the QuickPizza image from `0.15.25` to `0.15.27` across all deployment configurations.

## Changes

- **Docker Compose**: updated 4 files (monolithic + microservices, local-stack + cloud variants)
- **GitHub Actions**: updated 6 example workflow files with new `linux/amd64` digest (`be5efb0b...`)
- **Kubernetes**: updated 7 microservice deployment manifests
- **Terraform**: updated `quickpizza_image` (index digest `043ee661...`) and `quickpizza_image_version`
- **CLAUDE.md**: added version upgrade instructions documenting the two digest formats and all file locations

## Test Plan
- [ ] CI example workflows pass with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)