### PR TITLE
feat: add QUICKPIZZA_FAIL_RATE_CATALOG_DATABASE_RECORD_RECOMMENDATION fault injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ The application supports fault injection via HTTP headers and environment variab
 - `QUICKPIZZA_DELAY_FRONTEND_CSS_ASSETS` - Delay CSS asset serving
 - `QUICKPIZZA_DELAY_FRONTEND_PNG_ASSETS` - Delay PNG asset serving
 - `QUICKPIZZA_FAIL_RATE_RECOMMENDATIONS_API_PIZZA_POST` - Random failure rate (0-100) for `POST /api/pizza`
+- `QUICKPIZZA_FAIL_RATE_CATALOG_DATABASE_RECORD_RECOMMENDATION` - Random failure rate (0-100) for `RecordRecommendation` database calls; fails with a genuine PostgreSQL error (`column "nonexistent_column" does not exist`). Requires a PostgreSQL backend (`QUICKPIZZA_DB`)
 
 **Timeout testing example**: set `QUICKPIZZA_DELAY_RECOMMENDATIONS_API_PIZZA_POST=3s` with `QUICKPIZZA_PUBLIC_API_TIMEOUT=1s` to trigger 503 responses on pizza requests.
 

--- a/compose.grafana-cloud.microservices.yaml
+++ b/compose.grafana-cloud.microservices.yaml
@@ -58,6 +58,7 @@ services:
       QUICKPIZZA_ENABLE_CATALOG_SERVICE: "1"
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "catalog"
       QUICKPIZZA_OTEL_SERVICE_NAME: "catalog"
+      # QUICKPIZZA_FAIL_RATE_CATALOG_DATABASE_RECORD_RECOMMENDATION: 20
       # QUICKPIZZA_DB unset set to postgres. If empty, set to sqlite.
       QUICKPIZZA_DB: "${QUICKPIZZA_DB-postgres://postgres:postgres@quickpizza-db:5432/quickpizza_db?sslmode=disable}"
       # OTEL `db.name` span attribute. Used by servicegraph to create service nodes with this name

--- a/docs/inject-errors.md
+++ b/docs/inject-errors.md
@@ -28,6 +28,7 @@ The following environment variables are supported:
 - **QUICKPIZZA_DELAY_FRONTEND_PNG_ASSETS**: Adds delay when serving PNG image assets
 
 - **QUICKPIZZA_FAIL_RATE_RECOMMENDATIONS_API_PIZZA_POST**: Set to a number to fail `<number>%` of pizza POST requests randomly.
+- **QUICKPIZZA_FAIL_RATE_CATALOG_DATABASE_RECORD_RECOMMENDATION**: Set to a number to make `<number>%` of `RecordRecommendation` database calls fail with a genuine PostgreSQL error (`column "nonexistent_column" does not exist`). Requires a PostgreSQL backend (`QUICKPIZZA_DB`).
 
 ## Using HTTP Headers
 

--- a/pkg/database/catalog.go
+++ b/pkg/database/catalog.go
@@ -284,6 +284,11 @@ func (c *Catalog) RecordRecommendation(ctx context.Context, pizza *model.Pizza) 
 		return err
 	}
 
+	if util.FailRandomlyIfEnvSet("QUICKPIZZA_FAIL_RATE_CATALOG_DATABASE_RECORD_RECOMMENDATION") {
+		_, err := c.db.ExecContext(ctx, "SELECT nonexistent_column FROM pizzas LIMIT 1")
+		return err
+	}
+
 	pizza.DoughID = pizza.Dough.ID
 	return c.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		_, err := tx.NewInsert().Model(pizza).Exec(ctx)


### PR DESCRIPTION
## Summary
- Adds a new fault-injection env var that makes the Catalog service's `RecordRecommendation` database call fail with a genuine PostgreSQL error (`column "nonexistent_column" does not exist`), at a configurable failure rate.
- Useful for observability workshops that want to demonstrate realistic database-level failures (e.g. schema drift) distinct from HTTP-layer faults.

## Changes
- `pkg/database/catalog.go`: inject `SELECT nonexistent_column FROM pizzas LIMIT 1` before the insert transaction when `QUICKPIZZA_FAIL_RATE_CATALOG_DATABASE_RECORD_RECOMMENDATION` fires (requires PostgreSQL backend).
- `docs/inject-errors.md` and `CLAUDE.md`: document the new env var.
- `compose.grafana-cloud.microservices.yaml`: add a commented example on the catalog service.

## Test Plan
- [x] `go build ./...` passes
- [ ] Manually verify with `QUICKPIZZA_DB=postgres://...` and the env var set that `POST /api/pizza` intermittently fails with the injected PostgreSQL error

🤖 Generated with [Claude Code](https://claude.com/claude-code)