### PR TITLE
Add security reporting guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,3 +181,4 @@ grep -rn "quickpizza-local:" . --include="*.yaml" --include="*.yml" --include="*
 ```
 
 Confirm all occurrences show the new version. The `docker_publish.yaml` workflow is exempt — it derives the version dynamically from git release tags.
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
