### PR TITLE
chore: upgrade QuickPizza image to v0.15.28

### DIFF
--- a/.github/workflows/example_browser_tests.yaml
+++ b/.github/workflows/example_browser_tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 
@@ -65,7 +65,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_cli_flags_test.yaml
+++ b/.github/workflows/example_cli_flags_test.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_env_var.yaml
+++ b/.github/workflows/example_env_var.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3355:3333
 

--- a/.github/workflows/example_specific_k6_version.yaml
+++ b/.github/workflows/example_specific_k6_version.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_tests.yaml
+++ b/.github/workflows/example_tests.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 
@@ -36,7 +36,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/.github/workflows/example_verify_scripts.yaml
+++ b/.github/workflows/example_verify_scripts.yaml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.15.27@sha256:be5efb0bcbbed3ad0eb26cc6dc6a0d7ba74a3070be476f7b1859e88231983a4e # zizmor: ignore[unpinned-images]
+        image: ghcr.io/grafana/quickpizza-local:0.15.28@sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2 # zizmor: ignore[unpinned-images]
         ports:
           - 3333:3333
 

--- a/compose.grafana-cloud.microservices.yaml
+++ b/compose.grafana-cloud.microservices.yaml
@@ -48,7 +48,7 @@ services:
       - grpc
 
   catalog:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: catalog
     labels:
       - "service.type=application"
@@ -69,7 +69,7 @@ services:
         condition: service_healthy
 
   config:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: config
     labels:
       - "service.type=application"
@@ -84,7 +84,7 @@ services:
       QUICKPIZZA_CONF_FARO_APP_NAME: "${QUICKPIZZA_CONF_FARO_APP_NAME:-QuickPizza}"
       QUICKPIZZA_CONF_FARO_INSTRUMENTATION_ENABLE_REPLAY: "${QUICKPIZZA_CONF_FARO_INSTRUMENTATION_ENABLE_REPLAY:-false}"
   copy:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: copy
     labels:
       - "service.type=application"
@@ -106,7 +106,7 @@ services:
         condition: service_started
 
   public-api:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: public-api
     labels:
       - "service.type=application"
@@ -120,7 +120,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "public-api"
 
   recommendations:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: recommendations
     labels:
       - "service.type=application"
@@ -132,7 +132,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "recommendations"
 
   ws:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: ws
     labels:
       - "service.type=application"
@@ -144,7 +144,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "ws"
 
   grpc:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: grpc
     labels:
       - "service.type=application"

--- a/compose.grafana-cloud.monolithic.yaml
+++ b/compose.grafana-cloud.monolithic.yaml
@@ -31,7 +31,7 @@ services:
   quickpizza:
     # The QUICKPIZZA_IMAGE env. variable enables the use of a locally built image,
     # created with `make docker-build`.
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     # Alloy reads `container_name` to relabel service name in telemetry.
     container_name: quickpizza
     labels:

--- a/compose.grafana-local-stack.microservices.yaml
+++ b/compose.grafana-local-stack.microservices.yaml
@@ -52,7 +52,7 @@ services:
       - grpc
 
   catalog:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: catalog
     labels:
       - "service.type=application"
@@ -69,7 +69,7 @@ services:
         condition: service_healthy
 
   config:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: config
     labels:
       - "service.type=application"
@@ -80,7 +80,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_INSTANCE_ID: "config"
       QUICKPIZZA_OTEL_SERVICE_NAME: "config"
   copy:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: copy
     labels:
       - "service.type=application"
@@ -99,7 +99,7 @@ services:
         condition: service_started
 
   public-api:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: public-api
     labels:
       - "service.type=application"
@@ -113,7 +113,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "public-api"
 
   recommendations:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: recommendations
     labels:
       - "service.type=application"
@@ -125,7 +125,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "recommendations"
 
   ws:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: ws
     labels:
       - "service.type=application"
@@ -137,7 +137,7 @@ services:
       QUICKPIZZA_OTEL_SERVICE_NAME: "ws"
 
   grpc:
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: grpc
     labels:
       - "service.type=application"

--- a/compose.grafana-local-stack.monolithic.yaml
+++ b/compose.grafana-local-stack.monolithic.yaml
@@ -36,7 +36,7 @@ services:
   quickpizza:
     # The QUICKPIZZA_IMAGE env. variable enables the use of a locally built image,
     # created with `make docker-build`.
-    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.27}
+    image: ${QUICKPIZZA_IMAGE:-ghcr.io/grafana/quickpizza-local:0.15.28}
     container_name: quickpizza
     labels:
       - "service.type=application"

--- a/deployments/kubernetes/base/quickpizza/catalog.yaml
+++ b/deployments/kubernetes/base/quickpizza/catalog.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.27
+          image: ghcr.io/grafana/quickpizza-local:0.15.28
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/config.yaml
+++ b/deployments/kubernetes/base/quickpizza/config.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.27
+          image: ghcr.io/grafana/quickpizza-local:0.15.28
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/copy.yaml
+++ b/deployments/kubernetes/base/quickpizza/copy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.27
+          image: ghcr.io/grafana/quickpizza-local:0.15.28
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/grpc.yaml
+++ b/deployments/kubernetes/base/quickpizza/grpc.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.27
+          image: ghcr.io/grafana/quickpizza-local:0.15.28
           ports:
             - name: grpc
               containerPort: 3334

--- a/deployments/kubernetes/base/quickpizza/public-api.yaml
+++ b/deployments/kubernetes/base/quickpizza/public-api.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.27
+          image: ghcr.io/grafana/quickpizza-local:0.15.28
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/recommendations.yaml
+++ b/deployments/kubernetes/base/quickpizza/recommendations.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.27
+          image: ghcr.io/grafana/quickpizza-local:0.15.28
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/kubernetes/base/quickpizza/ws.yaml
+++ b/deployments/kubernetes/base/quickpizza/ws.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: quickpizza
-          image: ghcr.io/grafana/quickpizza-local:0.15.27
+          image: ghcr.io/grafana/quickpizza-local:0.15.28
           ports:
             - name: http
               containerPort: 3333

--- a/deployments/terraform/variables.tf
+++ b/deployments/terraform/variables.tf
@@ -45,21 +45,21 @@ variable "quickpizza_enforce_image_digest" {
 }
 
 variable "quickpizza_image" {
-  default     = "ghcr.io/grafana/quickpizza-local:0.15.27@sha256:043ee6616699a9dd49e5a2c55be039c79c1cac2d14ec0ce34333169deced98ab"
+  default     = "ghcr.io/grafana/quickpizza-local:0.15.28@sha256:c77804ab308f708f3c03d41ca413e7d0c5480144539e788d920bda46bb3abb64"
   description = "The Image to use for the QuickPizza Demo Application. Must use tag@sha256:digest format when quickpizza_enforce_image_digest is true."
   nullable    = false
   type        = string
 }
 
 variable "quickpizza_image_version" {
-  default     = "0.15.27"
+  default     = "0.15.28"
   description = "The version of the QuickPizza image. Must match the tag in quickpizza_image when quickpizza_enforce_image_digest is true."
   nullable    = false
   type        = string
 }
 
 variable "quickpizza_git_ref" {
-  default     = "c2cb21f"
+  default     = "d5608ca"
   description = "The GitHub reference to the specific commit of the QuickPizza version"
   nullable    = false
   type        = string


### PR DESCRIPTION
## Summary

Upgrades the QuickPizza image from `0.15.27` to `0.15.28` across all deployment configs, following the process documented in `CLAUDE.md`.

## Changes

- **Docker Compose** (16 entries): plain tag in `compose.grafana-local-stack.{monolithic,microservices}.yaml` and `compose.grafana-cloud.{monolithic,microservices}.yaml`
- **GitHub Actions example workflows** (8 entries): pinned to the linux/amd64 digest `sha256:715153869a32daa89f42b5e77a6bce9d9ae404acaca1fa4f0b294da23adb41a2`
- **Kubernetes manifests** (7 entries): plain tag under `deployments/kubernetes/base/quickpizza/`
- **Terraform** (`deployments/terraform/variables.tf`):
  - `quickpizza_image` pinned to the index digest `sha256:c77804ab308f708f3c03d41ca413e7d0c5480144539e788d920bda46bb3abb64`
  - `quickpizza_image_version` bumped to `0.15.28`
  - `quickpizza_git_ref` updated to `d5608ca` (the commit tagged `v0.15.28`). This was previously `c2cb21f`, which did not match `v0.15.27` either, so it had drifted.

## Test Plan

- Digests taken from `docker buildx imagetools inspect ghcr.io/grafana/quickpizza-local:0.15.28`
- `grep -rn "quickpizza-local:" . --include="*.yaml" --include="*.yml" --include="*.tf" | grep -v docker_publish` shows all 32 occurrences on `0.15.28`, with no `0.15.27` left
- Example workflows in CI exercise the new pinned image

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>